### PR TITLE
Adding ModelScope replacing UsingModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes are documented here. The format follows [Keep a Changelog](h
 
 ---
 
+## [0.14.1] — ModelScope + iOS 16 Bug Fixes
+
+### Added
+- **`ModelScope`** — new SwiftUI view that scopes observation to its content, preventing unnecessary parent re-renders. Wrapping reactive content in `ModelScope` confines observation to that sub-tree: only `ModelScope` re-renders when its accessed properties change, leaving the parent unaffected. Also fixes an iOS 16 issue where model properties accessed inside lazy `@ViewBuilder` closures (`.sheet`, `.popover`, `GeometryReader`, `NavigationStack` destinations) were not observed. On iOS 17 and later, `ModelScope` is a transparent pass-through — the platform already scopes observation per view boundary.
+
+### Deprecated
+- **`UsingModel`** — superseded by `ModelScope`. Replace `UsingModel(model) { model in … }` with `ModelScope { … }`, capturing the model from the enclosing scope. `ModelScope` naturally handles multiple models accessed in the same closure.
+
+### Fixed
+- **`@MainActor` missing from `mainCallQueueDrainLoop`** — on iOS 16, `objectWillChange.send()` could fire off the main thread after the drain loop's first `Task.yield()` suspension, breaking the `AccessCollector` observation path. Adding `@MainActor` ensures every batch — including post-yield batches — runs on the main thread.
+- **`containerIsSame` for `@ModelContainer` enums** — when an enum conforming to `Equatable` (via `@ModelContainer` synthesis or explicitly) was written with the same value, the write was incorrectly treated as a mutation, triggering spurious view re-renders and `onChange` callbacks. The equality check is now performed before recording a modification.
+
+---
+
 ## [0.14.0] — Exhaustivity Improvements + Convenience Helpers
 
 ### Added

--- a/Docs/Models.md
+++ b/Docs/Models.md
@@ -248,3 +248,25 @@ Stepper(value: $model.count) {
   Text("\(model.count)")
 }
 ```
+
+### ModelScope
+
+`ModelScope` is a view that scopes observation to its content, preventing unnecessary re-renders of the containing view. When a parent view accesses a model property, SwiftUI re-renders the *entire* parent on each change. Wrapping reactive content in `ModelScope` confines observation to that sub-tree — only the scope re-renders, leaving the parent unaffected.
+
+```swift
+struct TrackView: View {
+    var segment: SegmentModel  // no @ObservedModel — view stays stable
+
+    var body: some View {
+        baseTrackView
+            .overlay {
+                // Only this scope re-renders when isHovering changes.
+                ModelScope {
+                    if segment.isHovering { HoverOverlay() }
+                }
+            }
+    }
+}
+```
+
+`ModelScope` observes *all* models accessed inside the closure, so it naturally handles content that reads from multiple models at once. On iOS 17 and later it is a transparent pass-through — the platform already scopes observation per view boundary. On iOS 16 it also fixes an issue where model properties accessed inside lazy `@ViewBuilder` closures (`.sheet`, `.popover`, `GeometryReader`, `NavigationStack` destinations) are not observed unless wrapped in a `ModelScope`.

--- a/Docs/Testing.md
+++ b/Docs/Testing.md
@@ -25,18 +25,27 @@ import SwiftModel
 
 > Assertions must `await` because state and event propagation is asynchronous.
 
-### Xcodeproj App-Hosted Tests
+> **Swift 6.0:** The `.modelTesting` trait requires Swift 6.1 or later. On Swift 6.0, wrap your test body in `withModelTesting { }` instead:
+> ```swift
+> @Test func testAddCounter() async {
+>     await withModelTesting {
+>         let model = AppModel().withAnchor()
+>         // …
+>     }
+> }
+> ```
 
-SPM-based packages work with no extra configuration — `import SwiftModel` is all you need.
+### Xcodeproj Setup
 
-If your test target uses `BUNDLE_LOADER` (the Xcode default for xcodeproj targets that test an app binary), two build settings are required on the **app target** (not the test target):
+> **App target prerequisite:** Any Xcode app target using SwiftModel must add `OTHER_LDFLAGS = $(inherited) -weak_framework Testing` to its build settings. This is required for the app to launch, independently of whether you have any tests. See [Install](../README.md#install) in the README.
+
+If your test target uses `BUNDLE_LOADER` (the Xcode default for xcodeproj targets that test an app binary), one additional build setting is required on the **app target**:
 
 ```
 ENABLE_TESTING_SEARCH_PATHS = YES
-OTHER_LDFLAGS = $(inherited) -weak_framework Testing
 ```
 
-`ENABLE_TESTING_SEARCH_PATHS` makes the testing APIs available inside the app binary, which the test bundle inherits at runtime via `BUNDLE_LOADER`. `-weak_framework Testing` is required so the app doesn't crash at launch outside a test context — without it, `Testing.framework` is hard-linked and dyld fails to find it when the app runs standalone.
+`ENABLE_TESTING_SEARCH_PATHS` makes the testing APIs available inside the app binary, which the test bundle inherits at runtime via `BUNDLE_LOADER`.
 
 Do **not** add `SwiftModel` to the test target's Frameworks — the test bundle gets all symbols from the app, and adding extra links creates duplicate symbol errors.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,18 @@ Composable models for SwiftUI — struct-based, automatic async lifetime, exhaus
 ## Install
 
 ```swift
-.package(url: "https://github.com/bitofmind/swift-model", from: "0.13.0")
+.package(url: "https://github.com/bitofmind/swift-model", from: "0.14.1")
 ```
+
+**Xcode app targets:** SwiftModel references `Testing.framework` symbols at compile time (Xcode 16+). Without a weak link the app crashes at launch outside a test context with `Library not loaded: @rpath/Testing.framework/Testing`. Add this to your **app target's** build settings, regardless of whether you use SPM or xcodeproj to structure your project:
+
+```
+OTHER_LDFLAGS = $(inherited) -weak_framework Testing
+```
+
+**`swift build` / `swift test`** (command-line, no Xcode): no extra configuration required.
+
+If you also use app-hosted tests with `BUNDLE_LOADER`, one additional setting is required — see [Xcodeproj setup](Docs/Testing.md#xcodeproj-setup) in Testing.md.
 
 ## The core loop
 

--- a/Sources/SwiftModel/SwiftUI/ObservedModel.swift
+++ b/Sources/SwiftModel/SwiftUI/ObservedModel.swift
@@ -80,6 +80,11 @@ public extension Binding {
     }
 }
 
+/// A view that presents a model with observation enabled, passing it to a content closure.
+///
+/// > This view is deprecated. Use ``ModelScope`` instead — it covers all use cases
+/// > without requiring an explicit model parameter and no longer ties the scope to a single model type.
+@available(*, deprecated, message: "Use ModelScope instead.")
 public struct UsingModel<M: Model, Content: View>: View {
     @ObservedModel var model: M
     var content: (Binding<M>) -> Content
@@ -103,6 +108,98 @@ public struct UsingModel<M: Model, Content: View>: View {
 
     public var body: some View {
         content($model.binding)
+    }
+}
+
+/// A view that scopes observation to its content, preventing unnecessary
+/// re-renders of the containing view.
+///
+/// When a parent view accesses a model property, SwiftUI re-renders the
+/// *entire* parent whenever that property changes — even if the property is
+/// only used in a small part of the view hierarchy. Wrapping that part in
+/// `ModelScope` confines observation to the scope itself: only `ModelScope`
+/// re-renders when its accessed properties change, leaving the parent unaffected.
+///
+/// ```swift
+/// struct TrackView: View {
+///     var segment: SegmentModel  // no @ObservedModel — view is stable
+///
+///     var body: some View {
+///         baseTrackView
+///             .overlay {
+///                 // Only this scope re-renders when isHovering changes.
+///                 // Without ModelScope the overlay has no observation at all
+///                 // (no @ObservedModel in TrackView), or with @ObservedModel
+///                 // the entire TrackView re-renders for every hover change.
+///                 ModelScope {
+///                     if segment.isHovering { HoverOverlay() }
+///                 }
+///             }
+///     }
+/// }
+/// ```
+///
+/// `ModelScope` observes *all* models accessed inside the closure — not just
+/// one — so mixed-model content is naturally handled:
+///
+/// ```swift
+/// ModelScope {
+///     if segment.isHovering || editor.isExternalPaneActive { ... }
+/// }
+/// ```
+///
+/// ## Migrating from `UsingModel`
+///
+/// `UsingModel` is deprecated. `ModelScope` covers all its use cases without
+/// requiring an explicit model parameter — the content closure captures models
+/// from the enclosing scope:
+///
+/// ```swift
+/// // Before (deprecated):
+/// UsingModel(segment) { segment in
+///     if segment.isHovering { ... }
+/// }
+///
+/// // After:
+/// ModelScope {
+///     if segment.isHovering { ... }
+/// }
+/// ```
+///
+/// ## iOS 16 lazy-closure fix
+///
+/// `ModelScope` also fixes a secondary iOS 16 issue: certain SwiftUI APIs
+/// evaluate their `@ViewBuilder` content in a separate rendering context,
+/// breaking the observation chain if no scope boundary is present. Affected
+/// APIs include `ModalContext`, `GeometryReader`, `.sheet`, `.popover`,
+/// `.fullScreenCover`, and `NavigationStack` destination closures. On iOS 17
+/// and later, SwiftUI's `withObservationTracking` handles these automatically.
+///
+/// ```swift
+/// ModalContext {
+///     ModelScope {
+///         switch model.step { ... }
+///     }
+/// }
+/// ```
+public struct ModelScope<Content: View>: View {
+    @StateObject private var access = ViewAccess()
+    private let content: () -> Content
+
+    public init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    public var body: some View {
+        if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+            // On iOS 17+, SwiftUI wraps every view body in withObservationTracking,
+            // so the view boundary already scopes observation correctly.
+            content()
+        } else {
+            usingActiveAccess(access) {
+                content()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
**`ModelScope`** — new SwiftUI view that scopes observation to its content, preventing unnecessary parent re-renders. Wrapping reactive content in `ModelScope` confines observation to that sub-tree: only `ModelScope` re-renders when its accessed properties change, leaving the parent unaffected. Also fixes an iOS 16 issue where model properties accessed inside lazy `@ViewBuilder` closures (`.sheet`, `.popover`, `GeometryReader`, `NavigationStack` destinations) were not observed. On iOS 17 and later, `ModelScope` is a transparent pass-through — the platform already scopes observation per view boundary.