### PR TITLE
Work around Swift 6.3 `_read`-coroutine IRGen crash for function-typed @Model properties

### DIFF
--- a/Sources/SwiftModelMacros/Helpers.swift
+++ b/Sources/SwiftModelMacros/Helpers.swift
@@ -210,3 +210,37 @@ extension DeclGroupSyntax {
         }
     }
 }
+
+/// Returns true if the type syntax denotes a function type, looking through
+/// attributes (`@Sendable`/`@escaping`), `Optional` wrappers, and a single-element
+/// parenthesised tuple (`((X) -> Y)`).
+///
+/// Used to give function-typed `@Model` properties a plain `get` accessor instead
+/// of the usual `_read` coroutine — see `makeGetSet` in `ModelTrackedMacro` for why.
+func isFunctionType(_ type: TypeSyntax?) -> Bool {
+    guard let type else { return false }
+    if type.is(FunctionTypeSyntax.self) { return true }
+    if let attributed = type.as(AttributedTypeSyntax.self) {
+        return isFunctionType(attributed.baseType)
+    }
+    if let optional = type.as(OptionalTypeSyntax.self) {
+        return isFunctionType(optional.wrappedType)
+    }
+    if let iuo = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+        return isFunctionType(iuo.wrappedType)
+    }
+    // A parenthesised function type parses as a one-element tuple, e.g. `((X) -> Y)`.
+    if let tuple = type.as(TupleTypeSyntax.self), tuple.elements.count == 1,
+       let only = tuple.elements.first {
+        return isFunctionType(only.type)
+    }
+    return false
+}
+
+extension VariableDeclSyntax {
+    /// True when the (explicitly annotated) stored-property type is a function type.
+    /// Inferred closure properties (`var cb = { ... }`) have no annotation and report `false`.
+    var hasFunctionType: Bool {
+        isFunctionType(bindings.first?.typeAnnotation?.type)
+    }
+}

--- a/Sources/SwiftModelMacros/ModelMacro.swift
+++ b/Sources/SwiftModelMacros/ModelMacro.swift
@@ -22,16 +22,6 @@ private func inferType(from expr: ExprSyntax) -> String? {
     return nil
 }
 
-/// Returns true if the type syntax represents a function type (possibly wrapped in attributes).
-private func isFunctionType(_ type: TypeSyntax?) -> Bool {
-    guard let type else { return false }
-    if type.is(FunctionTypeSyntax.self) { return true }
-    if let attributed = type.as(AttributedTypeSyntax.self) {
-        return attributed.baseType.is(FunctionTypeSyntax.self)
-    }
-    return false
-}
-
 /// Returns the default value string for a parameter, considering the type and initializer.
 /// Optionals default to `nil` when no explicit initializer is provided (matching memberwise init).
 private func defaultValue(typeAnnotation: TypeSyntax?, initExpr: String?) -> String? {

--- a/Sources/SwiftModelMacros/ModelTrackedMacro.swift
+++ b/Sources/SwiftModelMacros/ModelTrackedMacro.swift
@@ -12,17 +12,56 @@ import SwiftSyntaxMacros
 ///
 /// Both write paths include a pending-state guard (`_storePendingIfNeeded`) for user-written
 /// inits where the setter fires instead of the init accessor.
+///
+/// `isFunctionType` properties get a plain `get` instead of `_read` **when this macro plugin
+/// is built with Swift 6.3**: swift-frontend 6.3 SIGSEGVs during IRGen when emitting a `_read`
+/// (yield-once) coroutine that yields a *function value by value* whose parameter is passed
+/// indirectly by the Swift calling convention (an aggregate of >4 fields). This is a
+/// platform-general `-Onone` bug — reproduced on both `aarch64-unknown-linux-android28` and
+/// `arm64-apple-macosx` debug builds (optimised builds inline the coroutine away and don't
+/// crash, which is why it first surfaced only in Imagien's debug Android cross-compile).
+/// A plain `get` (which returns a copy of the closure — trivial for a 2-word value) sidesteps it;
+/// it calls the same `_$modelSource[read:]` subscript, so observation is unchanged, and the write
+/// path (`_modify`, which yields an *address*, not a value) is unaffected.
+///
+/// The carve-out is gated on `#if compiler(>=6.4)` — i.e. on the Swift version, not the platform.
+/// It can't be scoped per-target anyway (the macro runs on the host and can't see the target, and
+/// `#if` can't switch between accessor *kinds* inside an accessor block), and it shouldn't be:
+/// the bug isn't Android-specific, so the `get` correctly applies on every platform under 6.3
+/// (harmless — a closure copy is ~free). Under Swift 6.4+ we emit `_read` again, unconditionally:
+/// if the bug was fixed this restores borrow-without-copy uniformly; if it regressed, debug builds
+/// crash here and surface it, rather than the workaround being carried silently forever. Delete
+/// this gate (and `isFunctionType`) once 6.3 support is dropped or the fix is confirmed.
 private func makeGetSet(
     identifier: String,
     didSet: CodeBlockItemListSyntax?,
-    willSet: CodeBlockItemListSyntax?
+    willSet: CodeBlockItemListSyntax?,
+    isFunctionType: Bool
 ) -> [AccessorDeclSyntax] {
-    let readAccessor: AccessorDeclSyntax =
+    let readCoroutine: AccessorDeclSyntax =
     """
     _read {
         yield _$modelSource[read: \\_State.\(raw: identifier), access: _$modelAccess]
     }
     """
+
+    let readAccessor: AccessorDeclSyntax
+    #if compiler(>=6.4)
+    // Swift 6.4+: emit the coroutine unconditionally (function types included). `isFunctionType`
+    // is intentionally unused here — the carve-out below only exists for the 6.3 compiler bug.
+    readAccessor = readCoroutine
+    #else
+    if isFunctionType {
+        readAccessor =
+        """
+        get {
+            _$modelSource[read: \\_State.\(raw: identifier), access: _$modelAccess]
+        }
+        """
+    } else {
+        readAccessor = readCoroutine
+    }
+    #endif
 
     let writeAccessor: AccessorDeclSyntax
     if didSet != nil || willSet != nil {
@@ -164,7 +203,7 @@ public struct ModelTrackedMacro: AccessorMacro, PeerMacro {
             """
         }
 
-        return [initAccessor] + makeGetSet(identifier: identifier, didSet: didSet, willSet: willSet)
+        return [initAccessor] + makeGetSet(identifier: identifier, didSet: didSet, willSet: willSet, isFunctionType: property.hasFunctionType)
     }
 
     public static func expansion<C: MacroExpansionContext, D: DeclSyntaxProtocol>(

--- a/Tests/SwiftModelMacroTests/ModelMacroTests.swift
+++ b/Tests/SwiftModelMacroTests/ModelMacroTests.swift
@@ -152,6 +152,118 @@ struct ModelMacroTests {
         }
     }
 
+    // The `get`-for-function-types carve-out is gated on Swift 6.3 (see ModelTrackedMacro.makeGetSet);
+    // under 6.4+ the macro emits `_read` again, so this expectation only holds while built with 6.3.
+    #if !compiler(>=6.4)
+    /// Function-typed stored properties get a plain `get` read accessor instead of `_read`.
+    ///
+    /// swift-frontend 6.3 SIGSEGVs during IRGen when emitting a `_read` (yield-once) coroutine
+    /// that yields a function value by value whose parameter is passed indirectly — a platform-general
+    /// `-Onone` bug (Apple + Android debug). The plain `get` (a copy) sidesteps it; the `nonmutating
+    /// _modify` write path — which yields an address, not a value — is unchanged. See `ModelTrackedMacro.makeGetSet`.
+    @Test func testModelClosureProperty() {
+        assertMacro {
+            """
+            @Model struct MyModel {
+                var handler: @Sendable () -> Void = {}
+            }
+            """
+        } expansion: {
+            #"""
+            struct MyModel {
+                var handler: @Sendable () -> Void {
+                    @storageRestrictions(initializes: _$modelAccess, _$modelSource)
+                    init(newValue) {
+                        _$modelAccess = _ModelAccessBox()
+                        _ModelSourceBox<Self>._threadLocalStoreFirst(\.handler, newValue)
+                        _$modelSource = ._popFromThreadLocal(Self._makeState)
+                    }
+                    get {
+                        _$modelSource[read: \_State.handler, access: _$modelAccess]
+                    }
+                    nonmutating _modify {
+                        yield &_$modelSource[write: \_State.handler, access: _$modelAccess]
+                    }
+                }
+
+                public nonisolated func visit<V: ModelVisitor<Self>>(with visitor: inout ContainerVisitor<V>) {
+                    visitor.visitStatically(statePath: \.handler)
+                }
+
+                public nonisolated struct _State: _ModelStateType {
+                    var handler: @Sendable () -> Void = {
+                    }
+                }
+
+                public typealias _ModelState = _State
+
+                private nonisolated static func _makeState(from pending: PendingStorage<_State>) -> _State {
+                    _State(handler: pending.value(for: \.handler, default: {
+                            }))
+                }
+
+                private nonisolated var _modelState: _State {
+                    get {
+                        _$modelSource._modelState
+                    }
+                    nonmutating set {
+                        _$modelSource._modelState = newValue
+                    }
+                }
+
+                private var _$modelAccess: _ModelAccessBox = _ModelAccessBox()
+
+                private var _$modelSource: _ModelSourceBox<Self> = ._popFromThreadLocal(Self._makeState)
+
+                public nonisolated static var _modelStateKeyPath: WritableKeyPath<Self, _State> {
+                    \Self._modelState
+                }
+
+                private nonisolated var _$modelContext: ModelContext<Self> {
+                    get {
+                        ModelContext(_access: _$modelAccess, _source: _$modelSource)
+                    }
+                }
+
+                public nonisolated var _context: ModelContextAccess<Self> {
+                    ModelContextAccess(_$modelContext)
+                }
+
+                public nonisolated mutating func _updateContext(_ update: ModelContextUpdate<Self>) {
+                    _$modelAccess = update._$modelContext._access
+                    _$modelSource = update._$modelContext._source
+                }
+            }
+
+            nonisolated extension MyModel: SwiftModel.Model {
+            }
+
+            nonisolated extension MyModel: @unchecked Sendable {
+            }
+
+            nonisolated extension MyModel: Identifiable {
+            }
+
+            nonisolated extension MyModel: CustomReflectable {
+                public var customMirror: Mirror {
+                    node.mirror(of: self, children: [("handler", handler as Any)])
+                }
+            }
+
+            nonisolated extension MyModel: CustomStringConvertible, CustomDebugStringConvertible {
+                public var description: String {
+                    node.description(of: self)
+                }
+                public var debugDescription: String {
+                    description
+                }
+            }
+            """#
+        }
+    }
+
+    #endif // !compiler(>=6.4)
+
     /// Model with an explicit type annotation but no default (requires user init).
     @Test func testModelCustomInit() {
         assertMacro {


### PR DESCRIPTION
## Problem

A `@Model` struct that stores a closure whose parameter is a large type crashes **swift-frontend 6.3** (SIGSEGV) during IR generation. It surfaced as a `signal 11` cross-compiling for `aarch64-unknown-linux-android28`, but it is **not Android-specific** — it reproduces identically on `arm64-apple-macosx` **debug** builds. Optimised (`-O`/release) builds inline the coroutine away and don't crash, which is the only reason it first showed up solely in a debug Android cross-compile.

```
While emitting IR SIL function "@…interactionPredicate…SbAA11InteractionOYbcvg"
 for getter for interactionPredicate
… compile command failed due to signal 11
```

## Root cause (upstream compiler bug, not a swift-model logic bug)

swift-frontend 6.3 mis-lowers a `_read` (yield-once) coroutine accessor that **yields a function value by value** when the function's *parameter* is passed **indirectly** by the Swift calling convention (an aggregate of >4 fields / >4 words). Minimal, swift-model-independent repro:

```swift
public struct Big: Sendable { var a=0,b=0,c=0,d=0,e=0 }   // 5 fields → passed indirectly
struct Box {
    private var _s: (Big) -> Bool = { _ in true }
    var cb: (Big) -> Bool { _read { yield _s } }            // 💥 IRGen SIGSEGV (debug)
}
```

Confirmed boundaries: 4-field param = OK, 5-field = crash; `@Sendable` not required; plain `get`, plain stored property, and the `_modify` *write* coroutine (yields an address, not a value) are all fine. `@Model` triggers it only because `@_ModelTracked` generates `_read`/`nonmutating _modify` accessors for every tracked stored property.

## Fix

Emit a plain `get` instead of `_read` for **function-typed** tracked properties:

```swift
get { _$modelSource[read: \_State.x, access: _$modelAccess] }   // was: _read { yield … }
```

- The `get` returns a copy of the closure — trivial for a 2-word value, and typically *cheaper* than a yield-once coroutine.
- It calls the same `_$modelSource[read:]` subscript, so **observation is unchanged**.
- The `nonmutating _modify`/`set` write path is untouched (it yields an address and doesn't crash).
- **Only function-typed properties change** — every other property keeps `_read`'s borrow-without-copy, which is the whole point of the coroutine accessors for large value types.

### Version-gated, so it auto-retires

The carve-out is gated on `#if compiler(>=6.4)` in the macro plugin (rebuilt per toolchain). Under 6.3 → `get`; under **6.4+ → `_read` again**. If the upstream bug is fixed, borrow-without-copy is restored uniformly; if it regressed, debug builds crash and surface it, rather than the workaround being carried silently forever.

It is **not** (and can't be) scoped per-platform: the macro runs on the host and can't see the target triple, and `#if` can't switch between accessor *kinds* inside an accessor block. That's fine — the bug is platform-general, so the `get` correctly applies everywhere under 6.3 (harmless).

## Limits

- Only **explicitly-annotated** function types are detected. An inferred `var cb = { … }` has no type syntax for the macro to inspect — annotate it (`var cb: @Sendable (X) -> Y = …`) and the macro handles it.
- Other closure-storage paths are already safe and unchanged: `@ModelDependency` already uses `get`; preference/environment values go through generic `get`/`set` + type-erased storage (verified: closure-valued env/preference keys build for Android).

## Verification

- The real-world model that SIGSEGV'd (a `@Model` with `@Sendable (Interaction) -> Bool`, `Interaction` being a multi-payload enum over large value types) now compiles for `aarch64-android` — built end-to-end against this branch.
- Full serial suite: **752/752 pass**.
- All 29 macro-expansion tests pass; new `testModelClosureProperty` (gated `#if !compiler(>=6.4)`) locks in the `get` expansion; existing expansions unchanged.

## Notes

- Targets `main`. The `test-access` branch (pinned by at least one downstream) may want this merged forward.
- An upstream Swift issue should be filed/linked so this `#if compiler(>=6.4)` carve-out can be deleted once the compiler fix ships.
