### PR TITLE
Pin swift-dependencies to 1.13.0; loosen xcode MCP rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes are documented here. The format follows [Keep a Changelog](h
 
 ---
 
+## [1.0.1] — Packaging fix: stable `swift-dependencies` pin
+
+### Fixed
+
+- **`swift-dependencies` is now referenced by a version requirement (`from: "1.13.0"`) instead of `branch: "main"`.** Depending on it by branch made `swift-model` itself an *unstable-version* package, so any downstream project that required `swift-model` by a stable version (e.g. `from: "1.0.0"`) failed to resolve with:
+
+  ```
+  'swift-model' is required using a stable-version but 'swift-model'
+  depends on an unstable-version package 'swift-dependencies'
+  ```
+
+  swift-dependencies 1.13.0 ships the trait-aware manifest the branch pin was waiting for, so the dependency can now point at a tagged release. The `#if swift(>=6.3)` gate around the `traits: ["Foundation", "Clocks"]` override is retained: 1.13.0 still ships the `Package@swift-6.0.swift` shadow manifest (no traits), which SE-0152 selects on toolchains < 6.3, where a `traits:` override would be a hard error. No source or API changes.
+
+---
+
 ## [1.0.0] — `@Model` Layout Redesign, Performance Overhaul + API Cleanup
 
 ### Changed
@@ -453,7 +468,8 @@ All APIs that were deprecated in prior releases have been removed:
 - `_printChanges()` / `_withPrintChanges()` — debug-build state change printing.
 - Example apps: `CounterFact`, `Standups`, `TodoList`.
 
-[Unreleased]: https://github.com/bitofmind/swift-model/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/bitofmind/swift-model/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/bitofmind/swift-model/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/bitofmind/swift-model/compare/0.14.0...1.0.0
 [0.14.0]: https://github.com/bitofmind/swift-model/compare/0.13.1...0.14.0
 [0.13.1]: https://github.com/bitofmind/swift-model/compare/0.13.0...0.13.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,11 +180,17 @@ When investigating new load flakes, check first whether the test matches this pa
 
 ## Building and testing with MCP
 
-**ALWAYS use the xcode-tools MCP server for building and running tests. Never fall back to `swift build` or `swift test` in Bash.**
+**Prefer the xcode MCP (`mcp__xcode__*`) for building and running tests — try it first.** It gives the richest inline diagnostics (compiler issues, test results, build logs). It is *preferred, not mandatory*: when its build/test tools hang or error, fall back rather than treating the MCP as the only option.
 
 - Use `BuildProject` to build.
 - Use `RunAllTests` to run the full suite, or `RunSomeTests` for specific tests.
 - **If a test target returns 0 results, it means it failed to compile — immediately call `GetBuildLog` to see the errors.**
+
+**Fallback rule — when a build/test MCP tool errors or times out, switch; don't retry.** The bridge drives Xcode over AppleEvents (macOS Automation permission), which can wedge — a common trigger is a stale "Allow access" dialog after an Xcode restart. Re-calling the same tool just hangs again (~60 s per timeout) and can wedge the whole bridge. Instead:
+
+- This is a pure SwiftPM package (no `.xcodeproj`/`.xcworkspace` on disk), so the `mcp__xcodebuild__*` Xcode-target tools (`build_macos`/`test_macos`/`build_sim`) don't apply here. Fall straight back to the Bash commands in **[Build & test](#build--test)** above — `scripts/test`, `swift build`, `swift test` — which is exactly what CI runs and gives the same compile/test signal.
+- `mcp__xcode__*`'s **read-only** tools (file reads, search, `GetBuildLog`, `XcodeListNavigatorIssues`, `XcodeRefreshCodeIssuesInFile`) are unaffected by the AppleEvent hang and stay reliable; only the build/test/preview tools are at risk. If the whole bridge is down, fall back to `Read`/`Grep`.
+- For a pure dependency/manifest change, `swift package resolve` is the targeted check — it validates resolution without a full build or test run.
 
 ### Reading test output
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,11 @@
 // swift-tools-version:6.1
 // Bumped from 6.0 to 6.1 for the `traits:` parameter on `.package(...)`, used by
-// swift-custom-dump below. swift-dependencies does NOT use traits here — it still ships
-// a `Package@swift-6.0.swift` shadow manifest that SE-0152 always selects over the
-// traits-aware `Package.swift`; any `traits:` override would be a hard error.
+// swift-custom-dump below (unconditionally) and swift-dependencies (only on
+// `swift(>=6.3)` — see the gate further down). swift-dependencies can't take an
+// unconditional `traits:` override: it still ships a `Package@swift-6.0.swift`
+// shadow manifest that SE-0152 selects on toolchains < 6.3 over the traits-aware
+// `Package.swift`, and that shadow declares no traits — so a `traits:` override
+// against it is a hard error.
 import Foundation
 import PackageDescription
 import CompilerPluginSupport
@@ -32,19 +35,23 @@ import CompilerPluginSupport
 // The WASM job uses 6.3, so it still gets the trait-gated,
 // CombineSchedulers-free tree.
 //
-// Retire this `#if` (and switch back to a tagged release) once
-// swift-dependencies drops the shadow manifest in `main` and cuts a tag ≥
-// PR #406.
+// swift-dependencies 1.13.0 shipped the trait-aware manifest (PR #406), so we
+// now pin a tagged release instead of `main`. The `#if swift(>=6.3)` gate must
+// stay, though: 1.13.0 STILL ships the `Package@swift-6.0.swift` shadow
+// manifest (no traits, unconditional CombineSchedulers), which SE-0152 selects
+// on toolchains < 6.3 — setting `traits:` against that manifest is a hard
+// error. Retire this `#if` only once swift-dependencies drops the shadow
+// manifest and cuts a tag without it.
 #if swift(>=6.3)
 let swiftDependenciesPackage: Package.Dependency = .package(
     url: "https://github.com/pointfreeco/swift-dependencies",
-    branch: "main",
+    from: "1.13.0",
     traits: ["Foundation", "Clocks"]
 )
 #else
 let swiftDependenciesPackage: Package.Dependency = .package(
     url: "https://github.com/pointfreeco/swift-dependencies",
-    branch: "main"
+    from: "1.13.0"
 )
 #endif
 


### PR DESCRIPTION
## What changed

1. **`Package.swift` — pin swift-dependencies to a tagged release.** Moved swift-dependencies off `branch: "main"` to `from: "1.13.0"` in both arms of the `#if swift(>=6.3)` gate. swift-dependencies 1.13.0 shipped the trait-aware manifest (our contribution, [PR #406](https://github.com/pointfreeco/swift-dependencies/pull/406)), so the branch pin is no longer needed.

2. **`CLAUDE.md` — loosen the xcode MCP rule to try-first, fall back.** Replaced the absolute "ALWAYS use the xcode MCP, never fall back to `swift build`/`swift test`" with a try-first-then-fall-back policy.

## Why the `#if swift(>=6.3)` gate stays

The original comment promised to retire the gate *and* switch to a tagged release once two conditions held. Only one is met by 1.13.0, verified against the tag:

| Condition | Status at 1.13.0 |
|---|---|
| Trait-aware manifest shipped (PR #406) | ✅ `Package.swift` (tools-version 6.3) declares `traits: [Clocks, CombineSchedulers, Foundation, FoundationNetworking]` |
| `Package@swift-6.0.swift` shadow manifest dropped | ❌ Still present — tools-version 6.0, **no traits**, unconditional `CombineSchedulers` |

Per SE-0152, toolchains < 6.3 still select the shadow manifest, and a `traits:` override against a manifest that declares none is a hard error. So we pin the tag but keep the dual-arm gate; the WASM CI (swift:6.3.0) still takes the traits arm and stays CombineSchedulers-free. Comments updated to reflect this.

## Why loosen the MCP rule

The old absolute rule contradicted the repo's own "Build & test" section (which documents `scripts/test` / `swift build`), and it bit during this work: the xcode MCP bridge wedged on an AppleEvent/Automation-permission hang (a stale "Allow access" dialog after an Xcode restart), and the "never fall back" wording offered no path forward. The new policy, modeled on `~/dev/parallel-apple`:

- Prefer `mcp__xcode__*`, try it first (best inline diagnostics) — but it's preferred, not mandatory.
- **Switch, don't retry** when a build/test tool errors or times out; re-calling just re-wedges the bridge.
- Fall back to the Bash commands already in **Build & test** (`scripts/test` / `swift build` / `swift test`) — this is a pure SwiftPM package with no `.xcodeproj`, so `mcp__xcodebuild__*`'s Xcode-target tools don't apply here.
- Read-only `mcp__xcode__*` tools stay reliable; `swift package resolve` is the targeted check for a dependency/manifest change.

## Verification

- `swift package resolve` → swift-dependencies pinned to `"version": "1.13.0"` (version, not branch revision).
- `swift build --build-tests` → **Build complete!** on Swift 6.3.2 — library, `@Model` macro plugin, all test targets, and benchmarks compile and link against 1.13.0 via the `traits: ["Foundation", "Clocks"]` arm.
- No new warnings introduced (the one `var m` warning in `ModelInitAccessorTests.swift` is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)