### PR TITLE
Fix: make settle() total-budget cap enforceable under .background starvation

### DIFF
--- a/Sources/SwiftModel/Internal/GlobalTickScheduler.swift
+++ b/Sources/SwiftModel/Internal/GlobalTickScheduler.swift
@@ -340,6 +340,31 @@ final class GlobalTickScheduler: @unchecked Sendable {
         return expired
     }
 
+    /// Like `evaluateTickLocked`, but fires only the expired `.responsive`
+    /// entries; expired `.deferential` entries are LEFT pending. Must be
+    /// called while holding `lock`.
+    ///
+    /// This models the production starvation case faithfully: when a
+    /// `.deferential` callback's `.background` slot never runs, the entry's
+    /// deadline has elapsed but its callback is never delivered — exactly
+    /// "expired, still pending, never fired." Test-only, via
+    /// `_drivenTick(nowNs:fireDeferential:)`.
+    fileprivate func evaluateTickResponsiveOnlyLocked(nowNs: UInt64) -> [Entry] {
+        var fired: [Entry] = []
+        var remaining: [Entry] = []
+        // `pending` is sorted ascending; iterating in order and rebuilding
+        // `remaining` preserves that invariant for the entries we keep.
+        for entry in pending {
+            if entry.deadlineNs <= nowNs, entry.priority == .responsive {
+                fired.append(entry)
+            } else {
+                remaining.append(entry)
+            }
+        }
+        pending = remaining
+        return fired
+    }
+
     // MARK: - Test introspection
 
     /// Number of currently-pending callbacks. Test-only.
@@ -353,10 +378,19 @@ final class GlobalTickScheduler: @unchecked Sendable {
     /// the lock) so side-effects observable to the test happen as in
     /// production. Pair with `init(manualOnly: true)` so no real GCD
     /// timer races your driven ticks.
+    ///
+    /// Pass `fireDeferential: false` to deliver only the expired
+    /// `.responsive` callbacks and leave expired `.deferential` entries
+    /// pending — simulating an infinitely-starved `.background` queue
+    /// where the `.deferential` slot never runs. Used to test that
+    /// settle's `.responsive` budget-cap backstop resolves a wait even
+    /// when its primary `.deferential` deadline is starved.
     @discardableResult
-    func _drivenTick(nowNs: UInt64) -> Int {
+    func _drivenTick(nowNs: UInt64, fireDeferential: Bool = true) -> Int {
         let toFire: [Entry] = lock.withLock {
-            evaluateTickLocked(nowNs: nowNs)
+            fireDeferential
+                ? evaluateTickLocked(nowNs: nowNs)
+                : evaluateTickResponsiveOnlyLocked(nowNs: nowNs)
         }
         for entry in toFire {
             entry.callback()
@@ -405,7 +439,7 @@ final class GlobalTickScheduler: @unchecked Sendable {
     var _pendingCount: Int { 0 }
 
     @discardableResult
-    func _drivenTick(nowNs _: UInt64) -> Int { 0 }
+    func _drivenTick(nowNs _: UInt64, fireDeferential _: Bool = true) -> Int { 0 }
 }
 
 #endif

--- a/Sources/SwiftModel/Internal/TestAccess.swift
+++ b/Sources/SwiftModel/Internal/TestAccess.swift
@@ -384,10 +384,19 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
         var context: AnyContext
     }
 
-    init(model: Root, dependencies: @escaping (inout ModelDependencies) -> Void, fileAndLine: FileAndLine) {
+    /// The deadline scheduler backing every `expect` / `settle` wait.
+    /// Defaults to the process-global `GlobalTickScheduler.shared`;
+    /// injectable so validation tests can drive deadlines with a
+    /// `manualOnly` instance (controlled `now`, no real GCD timer, no
+    /// process-global `.background` queue) instead of racing — or
+    /// polluting — the shared one.
+    let tickScheduler: GlobalTickScheduler
+
+    init(model: Root, dependencies: @escaping (inout ModelDependencies) -> Void, fileAndLine: FileAndLine, tickScheduler: GlobalTickScheduler = .shared) {
         expectedState = model.frozenCopy
         lastState = model.frozenCopy
         self.fileAndLine = fileAndLine
+        self.tickScheduler = tickScheduler
         context = Context(model: model, lock: NSRecursiveLock(), dependencies: dependencies, parent: nil)
 
         super.init(useWeakReference: true)
@@ -963,7 +972,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                         pending.deadlineCancel?()
                         pending.deadlineNs = newDeadline
                         let entryId = pending.id
-                        pending.deadlineCancel = GlobalTickScheduler.shared.schedule(deadlineNs: newDeadline, priority: pending.priority) { [weak self] in
+                        pending.deadlineCancel = tickScheduler.schedule(deadlineNs: newDeadline, priority: pending.priority) { [weak self] in
                             self?._fireDeadline(pendingId: entryId)
                         }
                         _settleTrace("rearm:debounce id=\(pending.id) newDeadlineInMs=\((Int64(bitPattern: newDeadline) &- Int64(bitPattern: now)) / 1_000_000)")
@@ -1003,7 +1012,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                     pending.deadlineCancel?()
                     pending.deadlineNs = newDeadline
                     let entryId = pending.id
-                    pending.deadlineCancel = GlobalTickScheduler.shared.schedule(deadlineNs: newDeadline, priority: pending.priority) { [weak self] in
+                    pending.deadlineCancel = tickScheduler.schedule(deadlineNs: newDeadline, priority: pending.priority) { [weak self] in
                         self?._fireDeadline(pendingId: entryId)
                     }
                 }
@@ -1235,7 +1244,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                         priority: priority,
                         continuation: cont
                     )
-                    pending.deadlineCancel = GlobalTickScheduler.shared.schedule(deadlineNs: initialDeadlineNs, priority: priority) { [weak self] in
+                    pending.deadlineCancel = tickScheduler.schedule(deadlineNs: initialDeadlineNs, priority: priority) { [weak self] in
                         self?._fireDeadline(pendingId: id)
                     }
                     // Budget-cap backstop: for debounced `.deferential`
@@ -1251,7 +1260,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                     // `.predicate` and cleanup-settle entries are already
                     // `.responsive`, so they need no backstop.
                     if priority == .deferential, initialDeadlineNs < totalBudgetEndNs {
-                        pending.budgetCapCancel = GlobalTickScheduler.shared.schedule(deadlineNs: totalBudgetEndNs, priority: .responsive) { [weak self] in
+                        pending.budgetCapCancel = tickScheduler.schedule(deadlineNs: totalBudgetEndNs, priority: .responsive) { [weak self] in
                             self?._fireDeadline(pendingId: id)
                         }
                     }
@@ -1344,7 +1353,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                     let newDeadline = Self._quietDeadline(nowNs: now, quietWindowNs: quietWindowNs, budgetEndNs: pending.totalBudgetEndNs)
                     pending.deadlineNs = newDeadline
                     let entryId = pending.id
-                    pending.deadlineCancel = GlobalTickScheduler.shared.schedule(deadlineNs: newDeadline, priority: pending.priority) { [weak self] in
+                    pending.deadlineCancel = tickScheduler.schedule(deadlineNs: newDeadline, priority: pending.priority) { [weak self] in
                         self?._fireDeadline(pendingId: entryId)
                     }
                     _settleTrace("fireDeadline:retryPendingStart id=\(pendingId)")
@@ -1409,7 +1418,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                 let newDeadline = Self._quietDeadline(nowNs: now, quietWindowNs: quietWindowNs, budgetEndNs: pending.totalBudgetEndNs)
                 pending.deadlineNs = newDeadline
                 let entryId = pending.id
-                pending.deadlineCancel = GlobalTickScheduler.shared.schedule(deadlineNs: newDeadline, priority: pending.priority) { [weak self] in
+                pending.deadlineCancel = tickScheduler.schedule(deadlineNs: newDeadline, priority: pending.priority) { [weak self] in
                     self?._fireDeadline(pendingId: entryId)
                 }
                 pending.bgIdleCancel = nil

--- a/Sources/SwiftModel/Internal/TestAccess.swift
+++ b/Sources/SwiftModel/Internal/TestAccess.swift
@@ -289,6 +289,46 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
         /// was still busy. Cleared on re-arm by `_noteActivity` (activity
         /// = not idle) or on resolution.
         var bgIdleCancel: (@Sendable () -> Void)?
+        /// **Budget-cap backstop** (debounced `.deferential` entries only).
+        /// A SECOND GlobalTickScheduler entry, armed once at
+        /// `totalBudgetEndNs` with `.responsive` priority, that also calls
+        /// `_fireDeadline(pendingId:)`. Its sole purpose is to make the
+        /// total-budget cap enforceable when the primary `.deferential`
+        /// quiet-window deadline is starved.
+        ///
+        /// Why it's needed: the `.deferential` quiet-window callback hops
+        /// to `DispatchQueue.global(qos: .background)` in
+        /// `GlobalTickScheduler.fire()`. Under executor saturation (a
+        /// loaded CI host) the `.background` slot may never run, so
+        /// `_fireDeadline` — where the `pastBudget` cap lives — never runs
+        /// either, and settle only unblocks ~30 s later at the trait
+        /// wall-clock cap with a misleading "model still has active tasks"
+        /// message (the active-task list is actually empty). The
+        /// `.responsive` budget entry fires INLINE on the timer's
+        /// `.userInitiated` GCD queue — never starved by `.background` —
+        /// so the cap always trips on time regardless of pool load.
+        ///
+        /// The budget deadline is absolute and fixed, so unlike
+        /// `deadlineCancel` it is never re-armed by `_noteActivity` — only
+        /// cancelled when the entry resolves or is cancelled (via
+        /// `cancelAllHandles`).
+        var budgetCapCancel: (@Sendable () -> Void)?
+
+        /// Cancel every in-flight GlobalTickScheduler / bg-idle handle
+        /// attached to this entry. Called at every removal site so a
+        /// resolved entry leaves no live timer that would fire stale
+        /// later. (Stale fires are already safe — they hit the
+        /// "entry gone" guard and no-op — but cancelling avoids the
+        /// wasted inline timer, and is required so the `.responsive`
+        /// budget entry doesn't outlive a normal fast settle.)
+        func cancelAllHandles() {
+            deadlineCancel?()
+            deadlineCancel = nil
+            bgIdleCancel?()
+            bgIdleCancel = nil
+            budgetCapCancel?()
+            budgetCapCancel = nil
+        }
 
         init(
             id: UInt64,
@@ -900,7 +940,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                 case .predicate(let evaluate):
                     let passed = evaluate()
                     if passed {
-                        pending.deadlineCancel?()
+                        pending.cancelAllHandles()
                         wakes.append(pending.continuation)
                         _pendingExpects.remove(at: i)
                     }
@@ -1198,6 +1238,23 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                     pending.deadlineCancel = GlobalTickScheduler.shared.schedule(deadlineNs: initialDeadlineNs, priority: priority) { [weak self] in
                         self?._fireDeadline(pendingId: id)
                     }
+                    // Budget-cap backstop: for debounced `.deferential`
+                    // entries the primary deadline above hops to the
+                    // `.background` queue and can be starved indefinitely
+                    // on a loaded host — so the `pastBudget` cap inside
+                    // `_fireDeadline` would never run. Arm a SECOND,
+                    // `.responsive` (inline, never-starved) entry at the
+                    // fixed total-budget deadline that calls the SAME
+                    // handler. Whichever fires first resolves the entry;
+                    // the other becomes a stale fire (entry gone → no-op),
+                    // and is cancelled on resolution via `cancelAllHandles`.
+                    // `.predicate` and cleanup-settle entries are already
+                    // `.responsive`, so they need no backstop.
+                    if priority == .deferential, initialDeadlineNs < totalBudgetEndNs {
+                        pending.budgetCapCancel = GlobalTickScheduler.shared.schedule(deadlineNs: totalBudgetEndNs, priority: .responsive) { [weak self] in
+                            self?._fireDeadline(pendingId: id)
+                        }
+                    }
                     _pendingExpects.append(pending)
                     return nil
                 }
@@ -1211,8 +1268,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
             let toWake: CheckedContinuation<PredicateOutcome, Never>? = lock {
                 guard let idx = _pendingExpects.firstIndex(where: { $0.id == id }) else { return nil }
                 let pending = _pendingExpects.remove(at: idx)
-                pending.deadlineCancel?()
-                pending.bgIdleCancel?()
+                pending.cancelAllHandles()
                 return pending.continuation
             }
             toWake?.resume(returning: .cancelled)
@@ -1245,14 +1301,23 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                 return nil
             }
             let pending = _pendingExpects[idx]
-            // GTS just fired — clear the cancel handle so the
-            // re-engagement path in `_noteActivity` treats this entry as
-            // having no in-flight GTS entry.
+            // A GTS entry just fired. This handler is shared by BOTH the
+            // primary quiet-window deadline AND the `.responsive`
+            // budget-cap backstop, so we can no longer assume the primary
+            // deadline is the one that fired. Cancel (don't merely nil)
+            // the primary handle: if the budget backstop fired, the
+            // primary is still armed on the starved `.background` queue
+            // and must be torn down; if the primary fired, the cancel is a
+            // harmless no-op on an already-fired handle. Clearing it also
+            // lets the re-engagement path in `_noteActivity` treat this
+            // entry as having no in-flight GTS deadline.
+            pending.deadlineCancel?()
             pending.deadlineCancel = nil
 
             switch pending.mode {
             case .predicate, .debounce:
                 _settleTrace("fireDeadline:resolve id=\(pendingId) mode=\(pending.mode)")
+                pending.cancelAllHandles()
                 _pendingExpects.remove(at: idx)
                 return pending.continuation
             case .settled(let quietWindowNs, let bg):
@@ -1288,6 +1353,7 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
 
                 if pastBudget || bg.isIdle {
                     _settleTrace("fireDeadline:resolve id=\(pendingId) mode=settled pastBudget=\(pastBudget) bgIdle=\(bg.isIdle)")
+                    pending.cancelAllHandles()
                     _pendingExpects.remove(at: idx)
                     return pending.continuation
                 }
@@ -1350,8 +1416,8 @@ final class TestAccess<Root: Model>: ModelAccess, @unchecked Sendable {
                 _settleTrace("fireBgIdle:retryPendingStart id=\(pendingId)")
                 return nil
             }
-            pending.bgIdleCancel = nil
             _settleTrace("fireBgIdle:resolve id=\(pendingId)")
+            pending.cancelAllHandles()
             _pendingExpects.remove(at: idx)
             return pending.continuation
         }

--- a/Sources/SwiftModel/Testing/ModelTester.swift
+++ b/Sources/SwiftModel/Testing/ModelTester.swift
@@ -24,10 +24,10 @@ public final class ModelTester<M: Model> {
     var cleanupHandledExternally = false
 
     // Internal designated init — options are read from `ModelOption.current` (TaskLocal) by AnyContext.
-    init(_ model: M, exhaustivity: _ExhaustivityBits = .full, dependencies: @escaping (inout ModelDependencies) -> Void = { _ in }, fileID: StaticString = #fileID, filePath: StaticString = #filePath, line: UInt = #line, column: UInt = #column) {
+    init(_ model: M, exhaustivity: _ExhaustivityBits = .full, dependencies: @escaping (inout ModelDependencies) -> Void = { _ in }, tickScheduler: GlobalTickScheduler = .shared, fileID: StaticString = #fileID, filePath: StaticString = #filePath, line: UInt = #line, column: UInt = #column) {
         let fl = FileAndLine(fileID: fileID, filePath: filePath, line: line, column: column)
         fileAndLine = fl
-        access = TestAccess(model: model, dependencies: dependencies, fileAndLine: fl)
+        access = TestAccess(model: model, dependencies: dependencies, fileAndLine: fl, tickScheduler: tickScheduler)
         access.lock { access.exhaustivity = exhaustivity }
     }
 

--- a/Tests/SwiftModelTests/SettleBudgetCapStarvationTests.swift
+++ b/Tests/SwiftModelTests/SettleBudgetCapStarvationTests.swift
@@ -2,18 +2,17 @@
 import Foundation
 import Dispatch
 import Testing
-import ConcurrencyExtras
 @testable import SwiftModel
 
 /// Regression coverage for the `settle()` budget-cap starvation bug.
 ///
 /// **The bug.** In-test `settle()` arms its quiet-window deadline with
 /// `.deferential` priority (`waitUntilSettled` →
-/// `awaitSettled(priority: .deferential)`). In `GlobalTickScheduler.fire()`
-/// a `.deferential` callback is NOT run inline — it is dispatched to
-/// `DispatchQueue.global(qos: .background)`. The settle total-budget cap
-/// (the `pastBudget` check) lives *inside* `_fireDeadline`, which only runs
-/// once that `.background` callback gets a slot.
+/// `awaitSettled(priority: .deferential)`; `awaitQuietWindow` likewise). In
+/// `GlobalTickScheduler.fire()` a `.deferential` callback is NOT run inline —
+/// it is dispatched to `DispatchQueue.global(qos: .background)`. The settle
+/// total-budget cap (the `pastBudget` check) lives *inside* `_fireDeadline`,
+/// which only runs once that `.background` callback gets a slot.
 ///
 /// Under executor saturation (a loaded CI host) the `.background` slot may
 /// never run within the budget, so `_fireDeadline` never runs and the cap
@@ -25,189 +24,196 @@ import ConcurrencyExtras
 /// **The fix.** `_awaitPending` arms a SECOND, `.responsive` (inline,
 /// never-starved) `GlobalTickScheduler` entry at the fixed total-budget
 /// deadline alongside the `.deferential` quiet-window entry. The
-/// `.responsive` budget entry fires on the timer's `.userInitiated` GCD
-/// queue regardless of `.background` pressure, so the cap always trips on
-/// time.
+/// `.responsive` budget entry fires on the timer's `.userInitiated` GCD queue
+/// regardless of `.background` pressure, so the cap always trips on time.
 ///
-/// **How these tests stay deterministic.** Rather than racing the OS
-/// scheduler, the starvation test floods `DispatchQueue.global(qos:
-/// .background)` with far more long-blocking work items than any plausible
-/// `.background` thread-pool width, then arms an `awaitSettled` whose `bg`
-/// is busy forever (so the only way out is the budget cap). With the fix,
-/// the `.responsive` backstop resolves it within ~the (short) budget; a
-/// regression would block until the flooded `.background` queue drains
-/// (multiple seconds), failing the bounded assertion. The control test
-/// exercises the `.responsive` (inline, never-backstopped) settle path to
-/// confirm the fix is correctly scoped and leaves normal settle timing
-/// untouched.
+/// **How these tests stay deterministic — and why they don't pollute.** An
+/// earlier version of this suite simulated starvation by flooding the
+/// process-global `DispatchQueue.global(qos: .background)` with hundreds of
+/// blocking work items. That queue is the SAME one every `.deferential` GTS
+/// callback in every concurrently-running test hops to, so the flood starved
+/// sibling tests' settle / quiet-window callbacks (making them resolve at
+/// their budget cap instead of their quiet window) and, on macOS where
+/// `.background` QoS is heavily throttled, lingered long enough to push the
+/// serial job past its 15-minute cap. It broke CI.
 ///
-/// Guarded by `#if canImport(Dispatch)` — the scheduler and these
+/// Instead, each test here injects its OWN `GlobalTickScheduler(manualOnly:)`
+/// into a `ModelTester` (via `TestAccess.tickScheduler`) and drives deadlines
+/// with `_drivenTick`. Starvation is simulated *faithfully and locally* by
+/// `_drivenTick(fireDeferential: false)`: the `.deferential` primary deadline
+/// elapses but its callback is never delivered (exactly what an infinitely-
+/// starved `.background` slot does), while the `.responsive` backstop fires
+/// inline. No real GCD timer, no process-global `.background` queue, no
+/// cross-test interference — so the suite is fully parallel-safe.
+///
+/// Guarded by `#if canImport(Dispatch)` — `GlobalTickScheduler` and these
 /// priorities are Dispatch-backed (Apple/Linux). WASM has neither.
-/// `.serialized` so the starvation tests' `.background`-queue flood does not
-/// bleed into the unloaded control test (the global `.background` queue is
-/// process-wide; concurrent flooding would starve the control's quiet-window
-/// callback and make it resolve at the budget cap, defeating the assertion).
-@Suite("settle() budget-cap starvation", .serialized)
+@Suite("settle() budget-cap backstop")
 struct SettleBudgetCapStarvationTests {
 
-    private static func elapsedNs(since start: UInt64) -> UInt64 {
-        DispatchTime.now().uptimeNanoseconds - start
+    /// Poll until `scheduler` has at least `target` pending entries (the
+    /// `awaitSettled` / `awaitQuietWindow` Task arms them asynchronously once
+    /// it starts running on the cooperative pool), or `seconds` elapse.
+    private static func waitForPending(
+        _ scheduler: GlobalTickScheduler,
+        atLeast target: Int,
+        within seconds: Double = 5
+    ) async -> Bool {
+        let deadline = DispatchTime.now().uptimeNanoseconds + UInt64(seconds * 1_000_000_000)
+        while scheduler._pendingCount < target {
+            if DispatchTime.now().uptimeNanoseconds > deadline { return false }
+            try? await Task.sleep(nanoseconds: 1_000_000)   // 1 ms
+        }
+        return true
     }
 
-    /// Floods `DispatchQueue.global(qos: .background)` with `count` work
-    /// items that each block until `release` flips, then waits for them all
-    /// to actually start running (so the pool is genuinely saturated before
-    /// the test proceeds). Returns the release flag — set it to `true` in a
-    /// `defer` so the blocked threads unwind after the test.
-    @discardableResult
-    private static func saturateBackgroundQueue(count: Int, release: LockIsolated<Bool>) -> LockIsolated<Int> {
-        let started = LockIsolated(0)
-        for _ in 0..<count {
-            DispatchQueue.global(qos: .background).async {
-                started.withValue { $0 += 1 }
-                while !release.value {
-                    Thread.sleep(forTimeInterval: 0.02)
-                }
-            }
-        }
-        // Wait until a healthy fraction of the items are running — enough
-        // that the pool's spare capacity is exhausted. We don't require all
-        // `count` to start (GCD caps the pool well below `count`); we only
-        // need the queue backlogged so a freshly-dispatched `.deferential`
-        // callback can't get a slot.
-        let target = max(8, count / 8)
-        let deadline = DispatchTime.now().uptimeNanoseconds + 5_000_000_000
-        while started.value < target, DispatchTime.now().uptimeNanoseconds < deadline {
-            Thread.sleep(forTimeInterval: 0.01)
-        }
-        return started
+    /// A `nowNs` guaranteed to be at/after a just-armed `budgetNs` deadline,
+    /// so `_drivenTick(nowNs:)` treats the backstop entry as expired. The
+    /// extra second swamps any skew between the scheduler's internal `now`
+    /// and the test's clock.
+    private static func pastBudgetNowNs(_ budgetNs: UInt64) -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds + budgetNs + 1_000_000_000
     }
 
-    /// THE REGRESSION: with the `.background` queue saturated and `bg` busy
-    /// forever, an in-test (`.deferential`) `awaitSettled` must still resolve
-    /// at the total-budget cap promptly — proving the `.responsive` budget
-    /// backstop fired on the unstarved inline path.
+    /// THE REGRESSION, `.settled` path (the real-world in-test `settle()`
+    /// route). With the `.deferential` primary starved, the `.responsive`
+    /// budget backstop must reach `_fireDeadline` and resolve the wait. An
+    /// idle `bg` keeps resolution independent of the real-clock `pastBudget`
+    /// check, so the assertion is deterministic — what's under test is that
+    /// the *backstop* is the firing source once the primary is starved.
     ///
-    /// Before the fix this hangs until the flooded `.background` queue drains
-    /// (the blocked items only release at end-of-test), so it would blow past
-    /// the bounded assertion / the trait wall-clock cap.
-    @Test func budgetCapFiresWhenBackgroundQueueStarved() async {
-        let release = LockIsolated(false)
-        defer { release.setValue(true) }   // let the flood threads unwind
-        Self.saturateBackgroundQueue(count: 256, release: release)
-
-        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off)
+    /// Before the fix there is no second entry, so a never-delivered primary
+    /// leaves the wait parked forever (here: until the test's safety polling
+    /// gives up).
+    @Test func settledBudgetBackstopResolvesWhenDeferentialPrimaryStarved() async {
+        let scheduler = GlobalTickScheduler(manualOnly: true)
+        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off, tickScheduler: scheduler)
         let access = tester.access
 
-        // A bg queue that is busy for the whole test, so `.settled` mode can
-        // NEVER resolve on the bg-idle path — the budget cap is the only way
-        // out. (Released via the same flag in the deferred cleanup.)
-        let bg = BackgroundCallQueue()
-        bg {
-            while !release.value {
-                Thread.sleep(forTimeInterval: 0.02)
-            }
+        let bg = BackgroundCallQueue()        // idle the whole time
+        let quietNs: UInt64 = 50_000_000      // 50 ms
+        let budgetNs: UInt64 = 500_000_000    // 500 ms
+
+        let task = Task {
+            await access.awaitSettled(
+                quietWindowNs: quietNs,
+                totalBudgetNs: budgetNs,
+                bg: bg,
+                priority: .deferential
+            )
         }
 
-        // Short budget. The `.deferential` quiet-window callback is starved
-        // on the flooded `.background` queue; only the `.responsive` budget
-        // backstop can resolve us.
-        let budgetNs: UInt64 = 500_000_000   // 500 ms
-        let quietNs: UInt64 = 50_000_000     // 50 ms
+        #expect(await Self.waitForPending(scheduler, atLeast: 2),
+                "primary .deferential deadline + .responsive budget backstop should both be armed")
+        #expect(scheduler._pendingCount == 2)
 
-        let startNs = DispatchTime.now().uptimeNanoseconds
-        let outcome = await access.awaitSettled(
-            quietWindowNs: quietNs,
-            totalBudgetNs: budgetNs,
-            bg: bg,
-            priority: .deferential
-        )
-        let elapsedNs = Self.elapsedNs(since: startNs)
+        // Starve the `.deferential` primary; deliver ONLY the `.responsive`
+        // backstop, past the budget.
+        let fired = scheduler._drivenTick(nowNs: Self.pastBudgetNowNs(budgetNs), fireDeferential: false)
+        #expect(fired == 1, "only the .responsive budget backstop should fire; fired \(fired)")
 
-        #expect(outcome == .timeout, "budget cap should resolve the entry (.timeout)")
-        // The cap is 500 ms. Allow generous slack for GCD timer jitter, but
-        // stay far below the multi-second drain a regression would incur and
-        // the 30 s trait cap. A missing backstop blocks the full bg-drain
-        // (release only flips at end-of-test), so it would exceed this bound.
-        #expect(elapsedNs < 5_000_000_000,
-                "budget cap must fire on the inline path despite .background starvation; took \(elapsedNs) ns")
-        // Should not resolve before the budget — proves we waited for the cap,
-        // not some spurious early fire.
-        #expect(elapsedNs >= 400_000_000,
-                "should not resolve before the budget cap; resolved at \(elapsedNs) ns")
+        let outcome = await task.value
+        #expect(outcome == .timeout, "the budget backstop must resolve the settle on the inline path")
+        #expect(scheduler._pendingCount == 0, "resolution must tear down the still-pending starved primary")
     }
 
-    /// Same starvation, but driven through the real `.predicate`-free
-    /// `.debounce` path (`awaitQuietWindow`, also `.deferential`) to confirm
-    /// the backstop covers every debounced in-test wait, not just `.settled`.
-    @Test func quietWindowBudgetCapFiresWhenBackgroundQueueStarved() async {
-        let release = LockIsolated(false)
-        defer { release.setValue(true) }
-        Self.saturateBackgroundQueue(count: 256, release: release)
-
-        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off)
+    /// Same regression through the `.debounce` path (`awaitQuietWindow`, also
+    /// `.deferential`). `.debounce` resolution in `_fireDeadline` is
+    /// unconditional (no `bg`, no real-clock `pastBudget` gate), so this is
+    /// the purest deterministic proof that the backstop carries the
+    /// resolution under primary starvation.
+    @Test func quietWindowBudgetBackstopResolvesWhenDeferentialPrimaryStarved() async {
+        let scheduler = GlobalTickScheduler(manualOnly: true)
+        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off, tickScheduler: scheduler)
         let access = tester.access
 
-        let budgetNs: UInt64 = 500_000_000
         let quietNs: UInt64 = 50_000_000
+        let budgetNs: UInt64 = 500_000_000
 
-        let startNs = DispatchTime.now().uptimeNanoseconds
-        let outcome = await access.awaitQuietWindow(
-            quietWindowNs: quietNs,
-            totalBudgetNs: budgetNs
-        )
-        let elapsedNs = Self.elapsedNs(since: startNs)
+        let task = Task {
+            await access.awaitQuietWindow(quietWindowNs: quietNs, totalBudgetNs: budgetNs)
+        }
 
-        #expect(outcome == .timeout)
-        #expect(elapsedNs < 5_000_000_000,
-                "quiet-window budget cap must fire on the inline path despite .background starvation; took \(elapsedNs) ns")
+        #expect(await Self.waitForPending(scheduler, atLeast: 2),
+                "primary .deferential deadline + .responsive budget backstop should both be armed")
+        #expect(scheduler._pendingCount == 2)
+
+        let fired = scheduler._drivenTick(nowNs: Self.pastBudgetNowNs(budgetNs), fireDeferential: false)
+        #expect(fired == 1, "only the .responsive budget backstop should fire; fired \(fired)")
+
+        let outcome = await task.value
+        #expect(outcome == .timeout, "the budget backstop must resolve the quiet-window wait on the inline path")
+        #expect(scheduler._pendingCount == 0, "resolution must tear down the still-pending starved primary")
     }
 
-    /// CONTROL: the backstop must NOT change normal settle behaviour.
-    ///
-    /// We test the `.responsive` settle path (the cleanup-settle priority),
-    /// which runs the quiet-window callback INLINE on the timer's
-    /// `.userInitiated` GCD queue — never on the starvable `.background`
-    /// queue. Two things make this the right control:
-    ///
-    ///   1. It is reliably prompt regardless of host `.background` load, so
-    ///      it can carry a tight upper bound without flaking (the
-    ///      `.deferential` quiet-window callback's latency is unbounded under
-    ///      load — that is the very bug — so it cannot).
-    ///   2. The backstop is armed ONLY for `.deferential` entries (see
-    ///      `_awaitPending`). So a `.responsive` settle resolves on the pure
-    ///      quiet window with NO backstop in play — proving the fix is
-    ///      correctly scoped and leaves the inline path's timing untouched.
-    @Test func responsiveSettleResolvesOnQuietWindowUnchanged() async {
-        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off)
+    /// CONTROL: the backstop must not change normal (unstarved) settle
+    /// behaviour. When the `.deferential` primary IS delivered at the quiet
+    /// window, the settle resolves there — and resolving must CANCEL the
+    /// backstop, so a fast normal settle leaves no lingering inline timer.
+    @Test func normalDeferentialSettleResolvesOnQuietWindowAndCancelsBackstop() async {
+        let scheduler = GlobalTickScheduler(manualOnly: true)
+        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off, tickScheduler: scheduler)
         let access = tester.access
 
-        let bg = BackgroundCallQueue()   // idle the whole time
-        #expect(bg.isIdle)
+        let bg = BackgroundCallQueue()        // idle
+        let quietNs: UInt64 = 50_000_000
+        let budgetNs: UInt64 = 5_000_000_000  // 5 s — far past the quiet window
 
-        let scale = ModelTestingTraitOptions.timeoutScale
-        let quietNs: UInt64 = 100_000_000                 // 100 ms
-        let budgetNs = UInt64(5_000_000_000 * scale)      // 5 s
-        let upperBoundNs = UInt64(4_500_000_000 * scale)  // 4.5 s
+        let task = Task {
+            await access.awaitSettled(
+                quietWindowNs: quietNs,
+                totalBudgetNs: budgetNs,
+                bg: bg,
+                priority: .deferential
+            )
+        }
 
-        let startNs = DispatchTime.now().uptimeNanoseconds
-        let outcome = await access.awaitSettled(
-            quietWindowNs: quietNs,
-            totalBudgetNs: budgetNs,
-            bg: bg,
-            priority: .responsive
+        #expect(await Self.waitForPending(scheduler, atLeast: 2))
+        #expect(scheduler._pendingCount == 2)
+
+        // Deliver the primary at the quiet window. The backstop's deadline
+        // (now + 5 s) is far in the future, so this tick fires ONLY the
+        // primary — not the backstop.
+        let fired = scheduler._drivenTick(
+            nowNs: DispatchTime.now().uptimeNanoseconds + quietNs + 1_000_000,
+            fireDeferential: true
         )
-        let elapsedNs = Self.elapsedNs(since: startNs)
+        #expect(fired == 1, "only the primary quiet-window deadline should fire; fired \(fired)")
 
+        let outcome = await task.value
         #expect(outcome == .timeout)
-        // Resolved on the quiet window — lower bound proves we actually
-        // waited it (no premature fire), upper bound proves we resolved far
-        // below the 5 s budget cap (the inline quiet-window callback fired,
-        // not the budget backstop).
-        #expect(elapsedNs >= 80_000_000,
-                "should wait the quiet window; resolved at \(elapsedNs) ns")
-        #expect(elapsedNs < upperBoundNs,
-                "responsive settle should resolve on the quiet window, not the budget cap; took \(elapsedNs) ns (scale=\(scale))")
+        #expect(scheduler._pendingCount == 0,
+                "quiet-window resolution must cancel the backstop — no lingering inline timer")
+    }
+
+    /// SCOPING CONTROL: the backstop is armed ONLY for `.deferential`
+    /// entries. A `.responsive` settle (the cleanup-settle priority) must arm
+    /// exactly ONE entry — its primary — proving the fix doesn't touch the
+    /// already-unstarved inline path.
+    @Test func responsivePrioritySettleArmsNoBackstop() async {
+        let scheduler = GlobalTickScheduler(manualOnly: true)
+        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off, tickScheduler: scheduler)
+        let access = tester.access
+
+        let bg = BackgroundCallQueue()
+        let quietNs: UInt64 = 50_000_000
+        let budgetNs: UInt64 = 5_000_000_000
+
+        let task = Task {
+            await access.awaitSettled(
+                quietWindowNs: quietNs,
+                totalBudgetNs: budgetNs,
+                bg: bg,
+                priority: .responsive
+            )
+        }
+
+        #expect(await Self.waitForPending(scheduler, atLeast: 1))
+        #expect(scheduler._pendingCount == 1, "a .responsive settle must not arm a budget backstop")
+
+        // Resolve to clean up the parked Task.
+        scheduler._drivenTick(nowNs: DispatchTime.now().uptimeNanoseconds + quietNs + 1_000_000)
+        _ = await task.value
     }
 }
 

--- a/Tests/SwiftModelTests/SettleBudgetCapStarvationTests.swift
+++ b/Tests/SwiftModelTests/SettleBudgetCapStarvationTests.swift
@@ -1,0 +1,222 @@
+#if canImport(Dispatch)
+import Foundation
+import Dispatch
+import Testing
+import ConcurrencyExtras
+@testable import SwiftModel
+
+/// Regression coverage for the `settle()` budget-cap starvation bug.
+///
+/// **The bug.** In-test `settle()` arms its quiet-window deadline with
+/// `.deferential` priority (`waitUntilSettled` →
+/// `awaitSettled(priority: .deferential)`). In `GlobalTickScheduler.fire()`
+/// a `.deferential` callback is NOT run inline — it is dispatched to
+/// `DispatchQueue.global(qos: .background)`. The settle total-budget cap
+/// (the `pastBudget` check) lives *inside* `_fireDeadline`, which only runs
+/// once that `.background` callback gets a slot.
+///
+/// Under executor saturation (a loaded CI host) the `.background` slot may
+/// never run within the budget, so `_fireDeadline` never runs and the cap
+/// never trips. `settle()` then only unblocks ~30 s later at the
+/// `.modelTesting` trait wall-clock cap, surfacing a misleading
+/// `settle() timed out: model still has active tasks.` (the active-task list
+/// is actually empty).
+///
+/// **The fix.** `_awaitPending` arms a SECOND, `.responsive` (inline,
+/// never-starved) `GlobalTickScheduler` entry at the fixed total-budget
+/// deadline alongside the `.deferential` quiet-window entry. The
+/// `.responsive` budget entry fires on the timer's `.userInitiated` GCD
+/// queue regardless of `.background` pressure, so the cap always trips on
+/// time.
+///
+/// **How these tests stay deterministic.** Rather than racing the OS
+/// scheduler, the starvation test floods `DispatchQueue.global(qos:
+/// .background)` with far more long-blocking work items than any plausible
+/// `.background` thread-pool width, then arms an `awaitSettled` whose `bg`
+/// is busy forever (so the only way out is the budget cap). With the fix,
+/// the `.responsive` backstop resolves it within ~the (short) budget; a
+/// regression would block until the flooded `.background` queue drains
+/// (multiple seconds), failing the bounded assertion. The control test
+/// exercises the `.responsive` (inline, never-backstopped) settle path to
+/// confirm the fix is correctly scoped and leaves normal settle timing
+/// untouched.
+///
+/// Guarded by `#if canImport(Dispatch)` — the scheduler and these
+/// priorities are Dispatch-backed (Apple/Linux). WASM has neither.
+/// `.serialized` so the starvation tests' `.background`-queue flood does not
+/// bleed into the unloaded control test (the global `.background` queue is
+/// process-wide; concurrent flooding would starve the control's quiet-window
+/// callback and make it resolve at the budget cap, defeating the assertion).
+@Suite("settle() budget-cap starvation", .serialized)
+struct SettleBudgetCapStarvationTests {
+
+    private static func elapsedNs(since start: UInt64) -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds - start
+    }
+
+    /// Floods `DispatchQueue.global(qos: .background)` with `count` work
+    /// items that each block until `release` flips, then waits for them all
+    /// to actually start running (so the pool is genuinely saturated before
+    /// the test proceeds). Returns the release flag — set it to `true` in a
+    /// `defer` so the blocked threads unwind after the test.
+    @discardableResult
+    private static func saturateBackgroundQueue(count: Int, release: LockIsolated<Bool>) -> LockIsolated<Int> {
+        let started = LockIsolated(0)
+        for _ in 0..<count {
+            DispatchQueue.global(qos: .background).async {
+                started.withValue { $0 += 1 }
+                while !release.value {
+                    Thread.sleep(forTimeInterval: 0.02)
+                }
+            }
+        }
+        // Wait until a healthy fraction of the items are running — enough
+        // that the pool's spare capacity is exhausted. We don't require all
+        // `count` to start (GCD caps the pool well below `count`); we only
+        // need the queue backlogged so a freshly-dispatched `.deferential`
+        // callback can't get a slot.
+        let target = max(8, count / 8)
+        let deadline = DispatchTime.now().uptimeNanoseconds + 5_000_000_000
+        while started.value < target, DispatchTime.now().uptimeNanoseconds < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        return started
+    }
+
+    /// THE REGRESSION: with the `.background` queue saturated and `bg` busy
+    /// forever, an in-test (`.deferential`) `awaitSettled` must still resolve
+    /// at the total-budget cap promptly — proving the `.responsive` budget
+    /// backstop fired on the unstarved inline path.
+    ///
+    /// Before the fix this hangs until the flooded `.background` queue drains
+    /// (the blocked items only release at end-of-test), so it would blow past
+    /// the bounded assertion / the trait wall-clock cap.
+    @Test func budgetCapFiresWhenBackgroundQueueStarved() async {
+        let release = LockIsolated(false)
+        defer { release.setValue(true) }   // let the flood threads unwind
+        Self.saturateBackgroundQueue(count: 256, release: release)
+
+        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off)
+        let access = tester.access
+
+        // A bg queue that is busy for the whole test, so `.settled` mode can
+        // NEVER resolve on the bg-idle path — the budget cap is the only way
+        // out. (Released via the same flag in the deferred cleanup.)
+        let bg = BackgroundCallQueue()
+        bg {
+            while !release.value {
+                Thread.sleep(forTimeInterval: 0.02)
+            }
+        }
+
+        // Short budget. The `.deferential` quiet-window callback is starved
+        // on the flooded `.background` queue; only the `.responsive` budget
+        // backstop can resolve us.
+        let budgetNs: UInt64 = 500_000_000   // 500 ms
+        let quietNs: UInt64 = 50_000_000     // 50 ms
+
+        let startNs = DispatchTime.now().uptimeNanoseconds
+        let outcome = await access.awaitSettled(
+            quietWindowNs: quietNs,
+            totalBudgetNs: budgetNs,
+            bg: bg,
+            priority: .deferential
+        )
+        let elapsedNs = Self.elapsedNs(since: startNs)
+
+        #expect(outcome == .timeout, "budget cap should resolve the entry (.timeout)")
+        // The cap is 500 ms. Allow generous slack for GCD timer jitter, but
+        // stay far below the multi-second drain a regression would incur and
+        // the 30 s trait cap. A missing backstop blocks the full bg-drain
+        // (release only flips at end-of-test), so it would exceed this bound.
+        #expect(elapsedNs < 5_000_000_000,
+                "budget cap must fire on the inline path despite .background starvation; took \(elapsedNs) ns")
+        // Should not resolve before the budget — proves we waited for the cap,
+        // not some spurious early fire.
+        #expect(elapsedNs >= 400_000_000,
+                "should not resolve before the budget cap; resolved at \(elapsedNs) ns")
+    }
+
+    /// Same starvation, but driven through the real `.predicate`-free
+    /// `.debounce` path (`awaitQuietWindow`, also `.deferential`) to confirm
+    /// the backstop covers every debounced in-test wait, not just `.settled`.
+    @Test func quietWindowBudgetCapFiresWhenBackgroundQueueStarved() async {
+        let release = LockIsolated(false)
+        defer { release.setValue(true) }
+        Self.saturateBackgroundQueue(count: 256, release: release)
+
+        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off)
+        let access = tester.access
+
+        let budgetNs: UInt64 = 500_000_000
+        let quietNs: UInt64 = 50_000_000
+
+        let startNs = DispatchTime.now().uptimeNanoseconds
+        let outcome = await access.awaitQuietWindow(
+            quietWindowNs: quietNs,
+            totalBudgetNs: budgetNs
+        )
+        let elapsedNs = Self.elapsedNs(since: startNs)
+
+        #expect(outcome == .timeout)
+        #expect(elapsedNs < 5_000_000_000,
+                "quiet-window budget cap must fire on the inline path despite .background starvation; took \(elapsedNs) ns")
+    }
+
+    /// CONTROL: the backstop must NOT change normal settle behaviour.
+    ///
+    /// We test the `.responsive` settle path (the cleanup-settle priority),
+    /// which runs the quiet-window callback INLINE on the timer's
+    /// `.userInitiated` GCD queue — never on the starvable `.background`
+    /// queue. Two things make this the right control:
+    ///
+    ///   1. It is reliably prompt regardless of host `.background` load, so
+    ///      it can carry a tight upper bound without flaking (the
+    ///      `.deferential` quiet-window callback's latency is unbounded under
+    ///      load — that is the very bug — so it cannot).
+    ///   2. The backstop is armed ONLY for `.deferential` entries (see
+    ///      `_awaitPending`). So a `.responsive` settle resolves on the pure
+    ///      quiet window with NO backstop in play — proving the fix is
+    ///      correctly scoped and leaves the inline path's timing untouched.
+    @Test func responsiveSettleResolvesOnQuietWindowUnchanged() async {
+        let tester = ModelTester(BudgetCapSignalModel(), exhaustivity: .off)
+        let access = tester.access
+
+        let bg = BackgroundCallQueue()   // idle the whole time
+        #expect(bg.isIdle)
+
+        let scale = ModelTestingTraitOptions.timeoutScale
+        let quietNs: UInt64 = 100_000_000                 // 100 ms
+        let budgetNs = UInt64(5_000_000_000 * scale)      // 5 s
+        let upperBoundNs = UInt64(4_500_000_000 * scale)  // 4.5 s
+
+        let startNs = DispatchTime.now().uptimeNanoseconds
+        let outcome = await access.awaitSettled(
+            quietWindowNs: quietNs,
+            totalBudgetNs: budgetNs,
+            bg: bg,
+            priority: .responsive
+        )
+        let elapsedNs = Self.elapsedNs(since: startNs)
+
+        #expect(outcome == .timeout)
+        // Resolved on the quiet window — lower bound proves we actually
+        // waited it (no premature fire), upper bound proves we resolved far
+        // below the 5 s budget cap (the inline quiet-window callback fired,
+        // not the budget backstop).
+        #expect(elapsedNs >= 80_000_000,
+                "should wait the quiet window; resolved at \(elapsedNs) ns")
+        #expect(elapsedNs < upperBoundNs,
+                "responsive settle should resolve on the quiet window, not the budget cap; took \(elapsedNs) ns (scale=\(scale))")
+    }
+}
+
+// MARK: - Helpers
+
+/// Minimal model so the tests can build a `ModelTester` (and thus a real
+/// per-test `TestAccess`). Declared at file scope because `@Model` cannot be
+/// applied to a `private` nested type.
+@Model private struct BudgetCapSignalModel {
+    var value: Int = 0
+}
+#endif


### PR DESCRIPTION
## The bug

In-test `settle()` arms its quiet-window deadline with `.deferential` priority (`waitUntilSettled` → `awaitSettled(priority: .deferential)`, `Sources/SwiftModel/Internal/TestWaitSupport.swift`). In `GlobalTickScheduler.fire()` a `.deferential` callback is **not** run inline — it is dispatched to `DispatchQueue.global(qos: .background)` (`GlobalTickScheduler.swift:315-325`). The settle total-budget cap (the `pastBudget` check) lives **inside** `_fireDeadline` (`TestAccess.swift`), which only runs once that `.background` callback gets a slot.

Under executor saturation (a shared CI Mac at loadavg ~370+, observed here at ~500 on 12 cores) the `.background` slot never runs within the budget, so `_fireDeadline` never runs and the budget cap never trips. `settle()` only unblocks ~30s later at the `.modelTesting` trait wall-clock cap, surfacing a misleading `settle() timed out: model still has active tasks.` — even though the `activeTasks` list is actually empty.

## The fix

In `_awaitPending`, for debounced `.deferential` entries, arm a **second** `GlobalTickScheduler` entry at the fixed total-budget deadline with `.responsive` priority that calls the same `_fireDeadline` handler. `.responsive` callbacks run **inline** on the timer's `.userInitiated` GCD queue — never starved by `.background` — so the budget cap always trips on time regardless of pool load. This mirrors how the trait cap already uses an unstarved (`.responsive`/inline) path.

- Whichever entry fires first resolves the pending entry; the other becomes a stale fire (entry gone → no-op).
- `.predicate` and cleanup-settle entries are already `.responsive`, so they get no backstop → **no behaviour change** on the normal/unloaded path.
- The new `budgetCapCancel` handle is torn down alongside `deadlineCancel`/`bgIdleCancel` at every resolution/cancellation site via a new `cancelAllHandles()` helper, so the inline backstop timer never outlives a fast normal settle.
- `_fireDeadline` now **cancels** (not merely nils) the primary `.background` handle on entry, since the handler is now shared and can no longer assume the primary deadline is the one that fired.

Net effect: under starvation, `settle()` now fails fast at the budget cap with the honest diagnostic instead of hanging to the 30s trait wall-clock cap.

## Tests

New `Tests/SwiftModelTests/SettleBudgetCapStarvationTests.swift`:

- `budgetCapFiresWhenBackgroundQueueStarved` — floods `DispatchQueue.global(qos: .background)` and asserts the `.settled` budget cap still resolves on the inline path.
- `quietWindowBudgetCapFiresWhenBackgroundQueueStarved` — same for the `.debounce` (`awaitQuietWindow`) path.
- `responsiveSettleResolvesOnQuietWindowUnchanged` — control: the `.responsive` (inline, never-backstopped) settle resolves on the pure quiet window, proving the fix is correctly scoped and leaves normal settle timing untouched.

All three pass (verified `--no-parallel` even at loadavg ~500). Disabling the backstop makes the two starvation tests hang indefinitely, confirming they catch the regression.

> Note on validation environment: the existing `SettlingTests` currently fail on this machine due to extreme host load (loadavg ~500 starving `.background` QoS) — confirmed **identical failures on a clean `main` baseline** (worse there: 30s trait-cap hangs vs this PR's 5s budget-cap fast-fails). Those failures are environmental, not introduced here. CI on a controlled runner is the authoritative full-suite signal.