### PR TITLE
Prepare 1.0.3 release; add scripts/release + release runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes are documented here. The format follows [Keep a Changelog](h
 
 ## [Unreleased]
 
+---
+
+## [1.0.3] — Read-path performance: `withUntrackedModelReads`, striped observer-KP cache, `@inlinable` hot path
+
 ### Added
 
 - **`withUntrackedModelReads { }` — public untracked/bulk-read scope.** Reads of `@Model` properties (and memoize/environment/preference values) inside the scope register no observation dependencies anywhere: no `ObservationRegistrar.access`, no `ModelAccess.willAccess` dispatch (view tracking / `ModelTester` / `Observed`), and no access stamping of returned child models. Reads reduce to a lock-protected raw state read — they still route through the context lock, so scanning while other threads write stays memory-safe (unlike the internal `forceDirectAccess` mechanism, which bypasses the lock and stays internal). Intended for O(N) traversals over live models on hot paths — hit-testing, snapping, validation passes — where per-read observation overhead dominates and the caller doesn't want a dependency on every visited property. Writes inside the scope notify normally. Framework-driven dependency collection is immune: `update()` (the engine under `node.memoize` and `Observed`) clears the flag around its `access()` evaluations, so a memoize set up inside an untracked scope still tracks its own dependencies. In the Release read-path benchmark an untracked read costs ~half a tracked read, and the n=120 two-property scan drops ~1.7x; a pre-extracted value snapshot remains far cheaper still for repeated scans (see the new *Performance* documentation article).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,40 @@ validates the framework's parallel-test claim; serial is the deterministic
 regression gate (caught the OR-path race fixed in 497c2ab). `fail-fast: false`
 on the matrices so one mode's flake doesn't suppress the other's signal.
 
+
 `swift-tools-version` is **6.1** — minimum required for the `traits:` parameter
 on `.package(...)`, used by the `swift-custom-dump` fork dependency. Pre-6.1
 Swift toolchains can't read this manifest.
+
+## Release process
+
+Releases are plain git tags (no `v` prefix: `1.0.2`, not `v1.0.2`) plus a GitHub
+release whose title is the bare version and whose notes are that version's
+CHANGELOG section body. The tag is lightweight and points at `main`'s tip at cut
+time (for 1.0.2 that was the latest merge commit, not the changelog commit).
+
+**CHANGELOG discipline**: every PR adds its entries to `## [Unreleased]` in
+`CHANGELOG.md` as part of the PR itself. Cutting a release is then just stamping
+that section with a version + title — never write release notes from scratch.
+
+To cut a release, run from a clean, up-to-date `main` checkout:
+
+```bash
+scripts/release 1.0.4 "Short descriptive title"   # add --dry-run to preview
+```
+
+The script does, in order: preflight checks (clean tree on synced `main`, `gh`
+authed, tag absent, non-empty `[Unreleased]`); stamps `CHANGELOG.md`
+(`## [Unreleased]` → `## [X.Y.Z] — Title`, fresh empty `[Unreleased]` above);
+commits as `Add X.Y.Z changelog entry` and pushes `main`; **waits for that
+push's CI run and aborts before tagging if it fails**; pushes the lightweight
+tag and runs `gh release create X.Y.Z --title X.Y.Z` with the section body
+(minus `---` separators) as notes.
+
+Title style matches the CHANGELOG headings — a terse summary of the dominant
+changes, e.g. "Linux `SIGSEGV` workaround + `settle()` budget-cap enforcement".
+
+If the script can't run (e.g. `main` is checked out in another worktree), the
+same steps work remotely: merge a PR that stamps the CHANGELOG, then
+`gh release create X.Y.Z --target <main-tip-sha> --title X.Y.Z --notes-file <notes>`
+— `gh` creates the tag on the target commit.

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Cut a SwiftModel release from the CHANGELOG's [Unreleased] section.
+#
+# Usage:
+#   scripts/release <version> "<short title>" [--dry-run] [--yes]
+#
+# Example:
+#   scripts/release 1.0.4 "Faster activation + memoize fixes"
+#
+# Mirrors how 1.0.0–1.0.3 were cut manually:
+#   1. Preflight: clean tree on an up-to-date `main`, `gh` authed, version not
+#      yet tagged, CHANGELOG has a non-empty [Unreleased] section.
+#   2. Stamps CHANGELOG.md: "## [Unreleased]" becomes "## [<version>] — <title>"
+#      with a fresh empty [Unreleased] section inserted above it.
+#   3. Commits as "Add <version> changelog entry" and pushes to main.
+#   4. Waits for the CI run on that push to finish — aborts before tagging if
+#      it fails.
+#   5. Pushes a lightweight tag `<version>` (no `v` prefix — matches every
+#      existing tag) and creates the GitHub release: title = bare version,
+#      notes = the stamped changelog section body (with `---` separators
+#      stripped).
+#
+# --dry-run prints the stamped heading and the release notes without touching
+# anything. --yes skips the confirmation prompt (for non-interactive use).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+VERSION="${1:-}"
+TITLE="${2:-}"
+DRY_RUN=0
+ASSUME_YES=0
+for arg in "${@:3}"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --yes|-y)  ASSUME_YES=1 ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$VERSION" || -z "$TITLE" ]]; then
+    echo "Usage: scripts/release <version> \"<short title>\" [--dry-run] [--yes]" >&2
+    exit 1
+fi
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: version must be X.Y.Z (no 'v' prefix), got '$VERSION'" >&2
+    exit 1
+fi
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+
+if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
+    echo "error: must run from main (currently on $(git rev-parse --abbrev-ref HEAD))" >&2
+    exit 1
+fi
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "error: working tree is not clean" >&2
+    exit 1
+fi
+git fetch origin --tags --quiet
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+    echo "error: local main is not in sync with origin/main" >&2
+    exit 1
+fi
+if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+    echo "error: tag $VERSION already exists" >&2
+    exit 1
+fi
+gh auth status >/dev/null 2>&1 || { echo "error: gh is not authenticated" >&2; exit 1; }
+grep -q '^## \[Unreleased\]' CHANGELOG.md || { echo "error: no [Unreleased] section in CHANGELOG.md" >&2; exit 1; }
+
+# Extract the [Unreleased] body (everything up to the next "## [" heading).
+UNRELEASED_BODY="$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)"
+if ! printf '%s\n' "$UNRELEASED_BODY" | grep -q '[^[:space:]-]'; then
+    echo "error: [Unreleased] section is empty — nothing to release" >&2
+    exit 1
+fi
+
+# Release notes: the section body minus the trailing "---" separators.
+NOTES="$(printf '%s\n' "$UNRELEASED_BODY" | sed -e '/^---$/d' | sed -e '/./,$!d')"
+
+echo "Release:  $VERSION — $TITLE"
+echo "Tagging:  $(git rev-parse --short HEAD) + the changelog commit"
+echo
+echo "── Release notes ──────────────────────────────────────────────────────"
+printf '%s\n' "$NOTES"
+echo "───────────────────────────────────────────────────────────────────────"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "(dry run — no changes made)"
+    exit 0
+fi
+if [[ "$ASSUME_YES" -ne 1 ]]; then
+    printf "Proceed with stamping, pushing main, tagging, and publishing? [y/N] "
+    read -r answer
+    [[ "$answer" == "y" || "$answer" == "Y" ]] || { echo "aborted"; exit 1; }
+fi
+
+# ── Stamp CHANGELOG ──────────────────────────────────────────────────────────
+
+awk -v ver="$VERSION" -v title="$TITLE" '
+    /^## \[Unreleased\]$/ && !done {
+        print "## [Unreleased]"
+        print ""
+        print "---"
+        print ""
+        print "## [" ver "] — " title
+        done=1
+        next
+    }
+    { print }
+' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+
+git add CHANGELOG.md
+git commit -m "Add $VERSION changelog entry"
+git push origin main
+SHA="$(git rev-parse HEAD)"
+echo "Pushed changelog commit $SHA"
+
+# ── Wait for CI ──────────────────────────────────────────────────────────────
+
+echo "Waiting for the CI run on $SHA to appear…"
+RUN_ID=""
+for _ in $(seq 1 30); do
+    RUN_ID="$(gh run list --commit "$SHA" --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+    [[ -n "$RUN_ID" && "$RUN_ID" != "null" ]] && break
+    sleep 10
+done
+if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+    echo "error: no CI run appeared for $SHA — tag manually once CI is green:" >&2
+    echo "  git tag $VERSION && git push origin refs/tags/$VERSION" >&2
+    exit 1
+fi
+echo "Watching CI run $RUN_ID (this takes ~6 minutes)…"
+gh run watch "$RUN_ID" --exit-status || {
+    echo "error: CI failed — NOT tagging. Investigate, then re-run the tag+release steps." >&2
+    exit 1
+}
+
+# ── Tag + GitHub release ─────────────────────────────────────────────────────
+
+git tag "$VERSION"
+git push origin "refs/tags/$VERSION"
+
+NOTES_FILE="$(mktemp)"
+printf '%s\n' "$NOTES" > "$NOTES_FILE"
+gh release create "$VERSION" --title "$VERSION" --notes-file "$NOTES_FILE"
+rm -f "$NOTES_FILE"
+
+echo "✅ Released $VERSION"


### PR DESCRIPTION
Stamps the CHANGELOG for **1.0.3 — Read-path performance: `withUntrackedModelReads`, striped observer-KP cache, `@inlinable` hot path** (the #18 + #19 round), and turns the manual release flow into automation + documentation:

- **`scripts/release X.Y.Z "Title" [--dry-run] [--yes]`** — mirrors how 1.0.0–1.0.2 were cut by hand: preflight (clean synced `main`, `gh` authed, tag absent, non-empty `[Unreleased]`), CHANGELOG stamping, `Add X.Y.Z changelog entry` commit + push, **CI gate before tagging**, lightweight `X.Y.Z` tag, GitHub release with the changelog section as notes.
- **CLAUDE.md "Release process" section** — the conventions (no `v` prefix, notes = changelog section, tag on `main`'s tip, per-PR `[Unreleased]` discipline, title style) so future agent sessions can cut releases unassisted.

After this merges, 1.0.3 is published with:
```
gh release create 1.0.3 --target <merge-sha> --title 1.0.3 --notes-file <section>
```
(remote-tag fallback, since `main` is checked out outside the working worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)