### PR TITLE
Fix unanchored optional/container child on same-id replace; expose modelID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes are documented here. The format follows [Keep a Changelog](h
 
 ## [Unreleased]
 
+### Fixed
+
+- **Replacing an optional `@Model` child (or any non-collection `ModelContainer`-typed property) with a new instance that reuses the existing child's explicit Identifiable `id` no longer leaves the new child unanchored.** The `ModelContainer` write path had a fast path — `if containerIsSame(newValue, container) { container = newValue; return }` — that, when the structure looked unchanged by `.id`, stored the assigned value *raw* and skipped `updateContext`. That is correct only when the assigned value is the already-anchored live child; for a *fresh* instance sharing an existing domain `id` (the case a `@Model` with an explicit, reusable `id` makes reachable) it stored a pre-anchor value with **no context** — the child silently dropped out of the hierarchy: no observation, no tasks, no `onActivate`, and reads returned its detached state. A SwiftUI view bound to such a child rendered its birth state and never updated. The fast path is removed; the path now always reconciles, so a same-`id` assignment reuses the existing child's context (continuity, matching the `[Model]` collection write path) and the child stays live. Genuine no-op write-backs stay cheap via the per-element `findOrTrackChild` fast path. Only same-`id` replacement was affected — different-`id` replacement and `nil`→value already anchored correctly.
+
+### Added
+
+- **`public var Model.modelID: ModelID` — the model's stable, per-instance identity.** Distinct from `id`: `id` is the `Identifiable` conformance and may be a *domain* value when a model declares its own `id` (e.g. a key reused by different instances over time), whereas `modelID` identifies *this specific instance*, is stable for its lifetime (assigned at construction, before anchoring, and carried into the live context), and is never reused. It is the reliable way to tell whether two model values refer to the same live instance; for a model without an explicit `id`, `modelID` and `id` are identical.
+
+- **DEBUG diagnostic for duplicate ids in a model collection.** Assigning a `[Model]` (or `IdentifiedArray`-style) collection in which two *distinct* instances share an Identifiable `id` now emits a `reportIssue` in DEBUG, mirroring SwiftUI's `ForEach` duplicate-id warning. Such elements are conflated onto a single child context (the duplicate resolves to the first's context and its state is lost), which previously failed silently. The check is keyed by `modelID`, so the *same* instance appearing more than once — legitimate model sharing — does not warn; only distinct instances colliding on one `id` are flagged.
+
 ---
 
 ## [1.0.4] — `node.memoize` produce-per-access fix + executor-drain test determinism

--- a/Sources/SwiftModel/Internal/Context.swift
+++ b/Sources/SwiftModel/Internal/Context.swift
@@ -1437,9 +1437,20 @@ final class Context<M: Model>: AnyContext, @unchecked Sendable {
     // MARK: - MutableCollection variants (no ModelContainer constraint)
     //
     // These mirror the existing ModelContainer-constrained overloads but work with any
-    // MutableCollection whose elements are Model & Identifiable. ModelRef uses only `id`
-    // (ModelID, globally unique) as the registry key — the outer `containerPath` dict key
-    // already distinguishes collections, so `id` alone disambiguates elements within a bucket.
+    // MutableCollection whose elements are Model & Identifiable. ModelRef uses the element's
+    // Identifiable `id` as the registry key — the outer `containerPath` dict key already
+    // distinguishes collections, so `id` alone disambiguates elements within a bucket.
+    //
+    // NOTE on `id`: this is the element's *Identifiable* `id`, NOT necessarily the per-instance
+    // `modelID`. For a default-`id` @Model the two coincide; a @Model that declares an explicit
+    // `id` shadows the default, so the key is that domain id. This is deliberate: `id` is the
+    // stable-identity slot key (the ForEach / IdentifiedArray model), so replacing an element with
+    // a NEW instance carrying an existing `id` CONTINUES the live child — its context, activation,
+    // tasks and state are preserved and the new instance's birth state is intentionally ignored
+    // (to change a child, mutate it; do not replace it). The required contract is the standard
+    // Identifiable one: `id` must be UNIQUE WITHIN THIS COLLECTION at any instant — two distinct
+    // instances sharing an `id` in one collection are conflated onto a single context. See
+    // ExplicitIdReplacementTests for the full characterization.
 
     /// Creates or retrieves the child context for a `MutableCollection` element,
     /// using `ModelRef(id: childModel.id)` as the registry key.
@@ -1568,17 +1579,20 @@ final class Context<M: Model>: AnyContext, @unchecked Sendable {
     //
     // These handle MutableCollection properties whose element type is `ModelContainer & Identifiable`
     // but the collection itself is NOT ModelContainer (e.g. IdentifiedArray<@ModelContainer enum>).
-    // Child model contexts are stored under `children[collectionPath]` using
-    // `ModelRef(id: childModel.id)` as the registry key. Model IDs (UUIDs) are globally unique,
-    // so no cursor key path is needed, eliminating the 3 heap allocations that cursor construction
-    // would otherwise require before every registry lookup.
+    // The inner child Model's context is stored under `children[collectionPath]` using
+    // `ModelRef(id: childModel.id)` (the inner Model's Identifiable id) as the registry key, with a
+    // constant `elementPath`, so no per-element cursor key path is needed — eliminating the 3 heap
+    // allocations that cursor construction would otherwise require before every registry lookup.
+    // As with `childContextForCollection`, `id` is the Identifiable id (== modelID only for a
+    // default-`id` @Model); see the stable-identity contract note there.
 
     /// Creates or retrieves the child context for a `Model` child inside a `ModelContainer`
     /// element of a `MutableCollection` that is not itself `ModelContainer`.
     ///
-    /// Uses `ModelRef(id: childModel.id)` as the registry key. Model IDs (UUIDs) are globally
-    /// unique, so no cursor key path is needed to disambiguate elements. This eliminates the 3
-    /// cursor allocations that would otherwise be required before every registry lookup.
+    /// Uses `ModelRef(id: childModel.id)` as the registry key with a constant `elementPath`, so no
+    /// cursor key path is needed to disambiguate elements. This eliminates the 3 cursor allocations
+    /// that would otherwise be required before every registry lookup. `id` is the element's
+    /// Identifiable id — see the stable-identity contract note above `childContextForCollection`.
     func childContextForContainerCollectionModel<C: MutableCollection, Child: Model>(
         collectionPath: WritableKeyPath<M, C>,
         childModel: Child

--- a/Sources/SwiftModel/Internal/ModelContext+Internal.swift
+++ b/Sources/SwiftModel/Internal/ModelContext+Internal.swift
@@ -140,9 +140,7 @@ extension Model {
         lifetime == .initial
     }
 
-    var modelID: ModelID {
-        modelContext.modelID
-    }
+    // `modelID` is declared as public API in Model.swift (per-instance identity).
 
     mutating func withContextAdded(context: Context<Self>) {
         // Transition @Model pending state to live before traversal reads _$modelSource paths.

--- a/Sources/SwiftModel/Model.swift
+++ b/Sources/SwiftModel/Model.swift
@@ -117,6 +117,18 @@ public extension Model {
     /// model type declares its own `id` property of a different type.
     var id: ModelID { modelID }
 
+    /// The model's stable, per-instance identity.
+    ///
+    /// Unlike ``id`` — which is the `Identifiable` conformance and may be a *domain* value when the
+    /// model declares its own `id` property (e.g. a reusable key shared by distinct instances over
+    /// time) — `modelID` is the framework-assigned identity of *this specific instance*. It is
+    /// stable for the instance's lifetime (assigned at construction, before anchoring, and carried
+    /// into the live context) and is never reused, so it is the reliable way to tell whether two
+    /// model values refer to the same live instance.
+    ///
+    /// For a model that does not declare an explicit `id`, `modelID` and `id` are identical.
+    var modelID: ModelID { modelContext.modelID }
+
     func onActivate() { }
 
     /// The runtime interface for this model.

--- a/Sources/SwiftModel/ModelContext.swift
+++ b/Sources/SwiftModel/ModelContext.swift
@@ -179,3 +179,33 @@ func _modelIsSame<T: Model>(_ lhs: T, _ rhs: Any) -> Bool {
     let rightOptional = rhs as! T
     return lhs.id == rightOptional.id
 }
+
+#if DEBUG
+/// DEBUG diagnostic: distinct model instances in one collection must not share an Identifiable
+/// `id` (the standard Identifiable/ForEach contract). Two *different* instances sharing an `id` are
+/// conflated onto a single child context — the duplicate resolves to the first's context and its
+/// state is lost, with no error. SwiftUI's `ForEach` reports an analogous runtime issue.
+///
+/// The check is by `modelID` (per-instance identity), NOT just `id`: the SAME model instance
+/// appearing multiple times in a collection is legitimate *sharing* (same `modelID`) and must not
+/// warn — only distinct instances (different `modelID`) colliding on one `id` are flagged. Called
+/// from the `Model`-element collection write path in `_ModelSourceBox`.
+func _warnOnDuplicateModelIDs<C: Collection>(_ collection: C) where C.Element: Model & Identifiable {
+    guard collection.count > 1 else { return }
+    var modelIDByID: [C.Element.ID: ModelID] = [:]
+    for element in collection {
+        let mid = element.modelID
+        if let existing = modelIDByID[element.id], existing != mid {
+            reportIssue(
+                "SwiftModel: two distinct model instances share id \(element.id) among " +
+                "\(C.Element.self) elements in a single collection. Collection elements must have " +
+                "unique ids (the Identifiable/ForEach contract); distinct instances sharing an id " +
+                "are conflated onto one child context and the duplicate's state is lost. (The same " +
+                "instance appearing more than once is fine — that is model sharing.)"
+            )
+            return
+        }
+        modelIDByID[element.id] = mid
+    }
+}
+#endif

--- a/Sources/SwiftModel/ModelSourceBox.swift
+++ b/Sources/SwiftModel/ModelSourceBox.swift
@@ -831,6 +831,10 @@ extension _ModelSourceBox {
         }
         guard let context = _modifyContext(accessBox: accessBox) else { return }
 
+#if DEBUG
+        _warnOnDuplicateModelIDs(newValue)
+#endif
+
         let modelPath = M._modelStateKeyPath.appending(path: statePath)
         var postLockCallbacks: [() -> Void] = []
         var structuralChange = false
@@ -994,13 +998,14 @@ extension _ModelSourceBox {
             context.stateTransaction(at: statePath, isSame: {
                 containerIsSame($0, $1)
             }, accessBox: accessBox, modify: { container in
-                // Fast path: if element structure is unchanged (same IDs in same order),
-                // skip the O(N) updateContext traversal — no child contexts need to change.
-                if containerIsSame(newValue, container) {
-                    container = newValue
-                    return
-                }
-
+                // NOTE: there is intentionally NO "same IDs ⇒ store newValue and return" fast path
+                // here. `containerIsSame` compares by Identifiable `.id`, which a fresh instance
+                // sharing an existing domain `id` also satisfies — storing such a pre-anchor value
+                // raw would leave the new child UNANCHORED (no context/observation/tasks). Always
+                // run `updateContext`: for a genuine no-op write-back its per-element
+                // `findOrTrackChild` fast path reuses the existing context cheaply (no onActivate
+                // churn); for a same-`.id` replacement it reuses the live child's context so the
+                // stored value stays anchored (continuity — matching the collection write path).
                 var newContainer = newValue
                 let prevDidReplace = threadLocals.didReplaceModelWithDestructedOrFrozenCopy
                 threadLocals.didReplaceModelWithDestructedOrFrozenCopy = false

--- a/Tests/SwiftModelTests/ExplicitIdReplacementTests.swift
+++ b/Tests/SwiftModelTests/ExplicitIdReplacementTests.swift
@@ -1,0 +1,186 @@
+import Testing
+@testable import SwiftModel
+
+// Characterization of SwiftModel's child-identity semantics for `@Model`s with an EXPLICIT,
+// reusable Identifiable `id` (e.g. imagien-apple's StreamModel `let id: StreamID`). These tests
+// document DESIGNED behavior, not a bug fix — they pass on stock SwiftModel.
+//
+// SwiftModel keys child-context identity by the element's Identifiable `.id` (Context.swift
+// `childContextForCollection` etc.). For a default-`id` @Model `.id` IS the globally-unique
+// `ModelID`; for an explicit reusable id it is the domain id. The contract is the ForEach /
+// IdentifiedArray stable-identity model: **same `.id` = the same logical child**. Consequences,
+// all verified below:
+//
+//   • Replacing a collection element / reassigning a collection with a NEW instance that has an
+//     EXISTING `.id` CONTINUES the existing live child: its context, activation, tasks and state
+//     are preserved, and the new instance's birth state is intentionally ignored. The child is the
+//     source of truth for its own state — to change it you MUTATE it, you do not replace it. (See
+//     ActivateTests.testChildrenCaseActivation, which depends on this continuity.)
+//   • Because nothing about the live child changed, such a reassignment fires no observation.
+//   • A DIFFERENT `.id` is a different child: fresh context, new state.
+//
+// The one genuinely sharp edge is two DISTINCT instances sharing one `.id` in a single collection
+// at the same instant — that violates the Identifiable uniqueness contract and conflates them.
+//
+// FIELD BUG NOTE: the StreamModel "frozen at birth state" symptom is this continuity contract met
+// by app misuse — replacing the pool element with a fresh same-id StreamModel (whose new state is
+// ignored) and/or binding the view to that fresh, never-anchored instance instead of mutating the
+// live pool child. The fix is app-side; see the investigation summary.
+
+@Suite(.modelTesting)
+struct ExplicitIdReplacementTests {
+    // Continuity: a captured value and the live slot share the one reused context after a same-id
+    // in-place replacement, so the captured value reflects subsequent live mutations.
+    @Test func capturedChildFollowsLiveAfterSameIdReplace() async {
+        let pool = ExIdPool(items: [ExIdItem(id: 1)]).withAnchor()
+        await settle {}
+        let captured = pool.items[0]
+        pool.items[0] = ExIdItem(id: 1, value: 0)   // new instance, same id → continues child
+        pool.items[0].value = 42                     // mutate the (continued) live child
+        await expect { pool.items[0].value == 42 }
+        await expect { captured.value == 42 }
+    }
+
+    @Test func mutationThroughCapturedReachesLiveAfterSameIdReplace() async {
+        let pool = ExIdPool(items: [ExIdItem(id: 1)]).withAnchor()
+        await settle {}
+        let captured = pool.items[0]
+        pool.items[0] = ExIdItem(id: 1, value: 0)
+        captured.value = 7
+        await expect { pool.items[0].value == 7 }
+    }
+}
+
+// Identity probes. Exhaustivity off: these read `.context` identity and use `#expect` directly
+// rather than driving the reactive system.
+@Suite(.modelTesting(exhaustivity: .off))
+struct ExplicitIdReconcileTests {
+    // Same-id replacement REUSES the existing context (continuity) and DISCARDS the new instance's
+    // state. To change the child you mutate it; replacing with a fresh same-id instance is a no-op
+    // for state. This is the behavior that surprised the field user.
+    @Test func sameIdReplaceReusesContextAndDiscardsNewState() async {
+        let pool = ExIdPool(items: [ExIdItem(id: 1, value: 99)]).withAnchor()
+        await settle {}
+        let before = ObjectIdentifier(pool.items[0].context!)
+        pool.items[0] = ExIdItem(id: 1, value: 5)
+        await settle {}
+        #expect(ObjectIdentifier(pool.items[0].context!) == before)  // context reused (continuity)
+        #expect(pool.items[0].value == 99)                           // new state discarded
+    }
+
+    // A DIFFERENT id is a different child: fresh context, new state applied.
+    @Test func differentIdReplaceMakesNewContext() async {
+        let pool = ExIdPool(items: [ExIdItem(id: 1, value: 99)]).withAnchor()
+        await settle {}
+        let before = ObjectIdentifier(pool.items[0].context!)
+        pool.items[0] = ExIdItem(id: 2, value: 5)
+        await settle {}
+        #expect(ObjectIdentifier(pool.items[0].context!) != before)
+        #expect(pool.items[0].value == 5)
+    }
+
+    // Removal tears the context down; a later same-id re-add is a genuinely new identity, and a
+    // value captured before removal stays pinned to the destructed context.
+    @Test func capturedValuePinnedAcrossRemoveAndReadd() async {
+        let pool = ExIdPool(items: [ExIdItem(id: 1, value: 11)]).withAnchor()
+        await settle {}
+        let captured = pool.items[0]
+        pool.items.removeAll()
+        await settle {}
+        pool.items.append(ExIdItem(id: 1, value: 22))   // same reusable domain id, new instance
+        await settle {}
+        // The re-added instance is live with its own new state.
+        #expect(pool.items[0].context != nil)
+        #expect(pool.items[0].value == 22)
+        // The captured value is pinned to its (torn-down) instance and does NOT follow the
+        // re-added one — it reads its last-seen state, not 22. (Don't compare context
+        // ObjectIdentifiers across teardown: a freed context's address can be reused.)
+        #expect(captured.value == 11)
+    }
+
+    // SHARP EDGE: two DISTINCT instances sharing one `.id` in a single collection are conflated
+    // onto one context (the second resolves to the first), and the second's state is lost. This
+    // violates the Identifiable/ForEach uniqueness contract; SwiftModel does not currently
+    // diagnose it (SwiftUI's ForEach reports a runtime issue for duplicate ids). Recommended
+    // framework improvement: a DEBUG `reportIssue` for duplicate ids in one collection.
+    @Test func duplicateDomainIdConflatesContexts() async {
+        let pool = ExIdPool(items: [ExIdItem(id: 1, value: 10), ExIdItem(id: 1, value: 20)]).withAnchor()
+        await settle {}
+        let c0 = pool.items[0].context.map(ObjectIdentifier.init)
+        let c1 = pool.items[1].context.map(ObjectIdentifier.init)
+        #expect(c0 == c1)                   // conflated onto a single context
+        #expect(pool.items[1].value == 10)  // index 1 reads index 0's state
+    }
+
+    // A duplicate-id collection WRITE now emits a DEBUG diagnostic (mirrors SwiftUI ForEach).
+    @Test func duplicateIdOnCollectionWriteEmitsDiagnostic() async {
+        let pool = ExIdPool(items: [ExIdItem(id: 1, value: 10)]).withAnchor()
+        await settle {}
+        withKnownIssue("duplicate ids in a model collection are diagnosed in DEBUG") {
+            pool.items = [ExIdItem(id: 2, value: 1), ExIdItem(id: 2, value: 2)]
+        }
+    }
+}
+
+@Model fileprivate struct ExIdPool { var items: [ExIdItem] = [] }
+@Model fileprivate struct ExIdItem { let id: Int; var value: Int = 0 }
+
+// Same-explicit-id replacement is INCONSISTENT across child shapes. These assert the CURRENT
+// behavior; the `optionalChild` case is a genuine bug (see comment).
+@Suite(.modelTesting(exhaustivity: .off))
+struct ExplicitIdShapeMatrixTests {
+    // Single `var child: M`: REPLACEMENT — new context, new state applied. (The single-Model write
+    // path skips by `modelID` and does removeChild + updateContext.)
+    @Test func singleChild_sameIdReplace() async {
+        let p = SMParent(child: SMChild(id: 1, value: 99)).withAnchor()
+        await settle {}
+        let before = p.child.context.map(ObjectIdentifier.init)
+        p.child = SMChild(id: 1, value: 5)
+        await settle {}
+        #expect(p.child.context != nil)                                    // anchored
+        #expect(p.child.context.map(ObjectIdentifier.init) != before)      // new context
+        #expect(p.child.value == 5)                                        // new state applied
+    }
+
+    // Collection `var items: [M]`: CONTINUITY — context reused, new state discarded.
+    @Test func collectionChild_sameIdReplace() async {
+        let p = ExIdPool(items: [ExIdItem(id: 1, value: 99)]).withAnchor()
+        await settle {}
+        let before = p.items[0].context.map(ObjectIdentifier.init)
+        p.items[0] = ExIdItem(id: 1, value: 5)
+        await settle {}
+        #expect(p.items[0].context.map(ObjectIdentifier.init) == before)   // context reused
+        #expect(p.items[0].value == 99)                                    // new state discarded
+    }
+
+    // Optional `var child: M?`: same-id replacement now keeps the child ANCHORED and follows the
+    // collection CONTINUITY semantics (context reused, new instance's state discarded). Previously
+    // this left the child unanchored (nil context) — the ModelContainer write fast-path stored the
+    // pre-anchor value raw; that fast path was removed. (Different-id replace and nil→set already
+    // anchored correctly.)
+    @Test func optionalChild_sameIdReplace_staysAnchored() async {
+        let p = OMParent(child: OMChild(id: 1, value: 99)).withAnchor()
+        await settle {}
+        let before = p.child?.context.map(ObjectIdentifier.init)
+        #expect(before != nil)                                             // initially anchored
+        p.child = OMChild(id: 1, value: 5)
+        await settle {}
+        #expect(p.child?.context != nil)                                   // FIXED: still anchored
+        #expect(p.child?.context.map(ObjectIdentifier.init) == before)     // context reused
+        #expect(p.child?.value == 99)                                      // continuity: old state
+    }
+
+    @Test func optionalChild_differentIdReplace_isAnchored() async {
+        let p = OMParent(child: OMChild(id: 1, value: 99)).withAnchor()
+        await settle {}
+        p.child = OMChild(id: 2, value: 5)
+        await settle {}
+        #expect(p.child?.context != nil)                                   // control: anchored
+        #expect(p.child?.value == 5)
+    }
+}
+
+@Model fileprivate struct SMParent { var child: SMChild }
+@Model fileprivate struct SMChild { let id: Int; var value: Int = 0 }
+@Model fileprivate struct OMParent { var child: OMChild? }
+@Model fileprivate struct OMChild { let id: Int; var value: Int = 0 }


### PR DESCRIPTION
## Summary

Investigating a field report (a SwiftUI `@ObservedModel` view stuck at a model's birth state, no observation, never recovering — for a `@Model` with an explicit, reusable Identifiable `id`) surfaced one genuine framework bug plus some related API/diagnostic/doc gaps.

### Fixed — optional/container child left unanchored on same-`id` replace

For a `@Model` with an **explicit, reusable `id`**, replacing an optional `@Model` child (`var child: M?`) — or any non-collection `ModelContainer`-typed property — with a *fresh* instance sharing the existing child's `id` left the new child **unanchored**:

- The `ModelContainer` write path had a fast path `if containerIsSame(newValue, container) { container = newValue; return }`. When the structure looked unchanged by `.id`, it stored the assigned value **raw** and skipped `updateContext`.
- That is correct only when the assigned value is the already-anchored live child. For a fresh instance reusing a domain `id`, it stored a pre-anchor value with **no context** — the child dropped out of the hierarchy: no observation, no tasks, no `onActivate`, reads returned its detached state. A view bound to it rendered birth state and never updated.

Fix: remove the fast path so the write always reconciles, reusing the existing child's context (continuity — matching the `[Model]` collection write path). Genuine no-op write-backs stay cheap via the per-element `findOrTrackChild` fast path. Only same-`id` replacement was affected; different-`id` and `nil`→value already anchored correctly.

### Added

- **`public var Model.modelID: ModelID`** — the stable, per-instance identity, distinct from the (possibly domain-valued) `Identifiable` `id`. The reliable way to tell whether two model values refer to the same live instance. (Moved from the internal accessor; identical to `id` for models without an explicit `id`.)
- **DEBUG duplicate-id diagnostic** — assigning a model collection with two *distinct* instances sharing an `id` now `reportIssue`s (mirroring SwiftUI `ForEach`). Keyed by `modelID`, so legitimate sharing (the *same* instance appearing more than once) does not warn.

### Docs / tests

- Corrected the misleading "globally-unique ModelID / UUIDs" registry-key comments to describe the real same-`.id` stable-identity continuity contract.
- Added `ExplicitIdReplacementTests` characterizing behavior across single / optional / collection child shapes.

## A known semantic difference (intentionally not changed here)

Same-`id` replacement now behaves like this:

| `var child: M` | `var child: M?` | `var items: [M]` |
|---|---|---|
| **replace** (new state) | **continuity** (this PR) | **continuity** |

The single-child path still *replaces* while collection/optional *continue*. Unifying on "replace everywhere" is not viable — it breaks `ActivateTests.testChildrenCaseActivation`, which depends on a fresh same-`id` element continuing the existing child. Unifying on "continuity everywhere" (bring single-child into line) is plausible but is a behavior change to the common `model.child = X` assignment and deserves its own PR/decision. Left as a follow-up.

## Validation

Full suite green on **both serial and parallel** (781 tests; only the documented known-issue flakes). Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)