### PR TITLE
Unify single-child same-id assignment on continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes are documented here. The format follows [Keep a Changelog](h
 
 ## [Unreleased]
 
+### Changed
+
+- **Assigning a new instance to a single `@Model` child property is now consistent with collections and optionals: a same-`id` assignment continues the existing live child instead of replacing it.** Previously `model.child = NewChild(...)` always replaced (tore the old child down, anchored the new one) even when the new instance reused the existing child's Identifiable `id`, while `[Model]` and `Model?` properties treated a same-`id` assignment as *continuity* (the existing live child is kept, the new instance's state ignored). All child shapes now follow one rule: **`.id` is identity — to change a child you mutate it; assigning a fresh instance that reuses an existing `id` continues that child, and only a *different* `id` is a replacement.** This only affects `@Model` types that declare an explicit, reusable `id`; for a default-`id` model `.id == modelID`, so every distinct instance still replaces exactly as before. To intentionally swap in different state under the same domain key, either mutate the existing child or give the new instance a distinct `id`.
+
 ---
 
 ## [1.0.5] — Same-`id` child-replace anchoring fix; `Model.modelID` + `settle`/`expect` runaway-source diagnostic

--- a/Sources/SwiftModel/ModelSourceBox.swift
+++ b/Sources/SwiftModel/ModelSourceBox.swift
@@ -770,11 +770,21 @@ extension _ModelSourceBox {
 
             let modelPath = M._modelStateKeyPath.appending(path: statePath)
             var callbacks: [() -> Void] = []
+            // Identity is the Identifiable `.id` (the stable-identity contract shared with the
+            // collection and optional/`ModelContainer` write paths): assigning a fresh instance
+            // that reuses the existing child's `.id` CONTINUES that live child rather than replacing
+            // it — its context, activation, tasks and state are preserved and the new instance's
+            // state is ignored (to change a child, mutate it). Only a DIFFERENT `.id` is a genuine
+            // replacement. For a default-`id` @Model `.id == modelID`, so this is unchanged there;
+            // it only affects models with an explicit, reusable `id`.
             context.stateTransaction(at: statePath, isSame: {
-                $0.modelID == $1.modelID
+                $0.id == $1.id
             }, accessBox: accessBox, modify: { child in
                 var newChild = newValue
-                if let childContext = child.context {
+                // Tear down the old child only on a real replacement (different `.id`). For a
+                // same-`.id` assignment, leaving the existing context registered lets
+                // `updateContext` reuse it — continuity, matching the collection write path.
+                if let childContext = child.context, child.id != newValue.id {
                     context.removeChild(childContext, at: \M.self, callbacks: &callbacks)
                 }
                 context.updateContext(for: &newChild, at: modelPath)

--- a/Tests/SwiftModelTests/ExplicitIdReplacementTests.swift
+++ b/Tests/SwiftModelTests/ExplicitIdReplacementTests.swift
@@ -129,8 +129,9 @@ struct ExplicitIdReconcileTests {
 // behavior; the `optionalChild` case is a genuine bug (see comment).
 @Suite(.modelTesting(exhaustivity: .off))
 struct ExplicitIdShapeMatrixTests {
-    // Single `var child: M`: REPLACEMENT — new context, new state applied. (The single-Model write
-    // path skips by `modelID` and does removeChild + updateContext.)
+    // Single `var child: M`: CONTINUITY — same-`.id` assignment reuses the existing child's
+    // context and discards the new instance's state, consistent with the optional and collection
+    // write paths. (Previously this replaced; unified so `.id` is identity across all child shapes.)
     @Test func singleChild_sameIdReplace() async {
         let p = SMParent(child: SMChild(id: 1, value: 99)).withAnchor()
         await settle {}
@@ -138,6 +139,17 @@ struct ExplicitIdShapeMatrixTests {
         p.child = SMChild(id: 1, value: 5)
         await settle {}
         #expect(p.child.context != nil)                                    // anchored
+        #expect(p.child.context.map(ObjectIdentifier.init) == before)      // context reused
+        #expect(p.child.value == 99)                                       // new state discarded
+    }
+
+    // Single `var child: M`: a DIFFERENT `.id` is a genuine replacement — new context, new state.
+    @Test func singleChild_differentIdReplace() async {
+        let p = SMParent(child: SMChild(id: 1, value: 99)).withAnchor()
+        await settle {}
+        let before = p.child.context.map(ObjectIdentifier.init)
+        p.child = SMChild(id: 2, value: 5)
+        await settle {}
         #expect(p.child.context.map(ObjectIdentifier.init) != before)      // new context
         #expect(p.child.value == 5)                                        // new state applied
     }


### PR DESCRIPTION
## Summary

Follow-up to #26. Makes the **single `@Model` child** write path consistent with the collection (`[Model]`) and optional (`Model?`) paths for same-`id` assignment.

Before this PR, the three child shapes disagreed on what `child = NewInstance(sameId)` means for a `@Model` with an **explicit, reusable `id`**:

| `var child: M` | `var child: M?` | `var items: [M]` |
|---|---|---|
| **replace** (new state) | continuity | continuity |

This unifies them on **continuity**, so there is one rule across all shapes:

> **`.id` is identity.** To change a child you *mutate* it. Assigning a fresh instance that reuses an existing `id` *continues* that live child (its context, activation, tasks and state are preserved; the new instance's state is ignored). Only a *different* `id` is a replacement.

## Change

In the single-Model write path (`ModelSourceBox` `subscript<T: Model>` set):
- Tear down the old child only on a **different** `.id` (`child.id != newValue.id`); a same-`id` assignment leaves the existing context registered so `updateContext` reuses it (continuity).
- Key the write-skip by `.id` (was `modelID`) so a same-`id` assignment fires no spurious observation, matching the collection/optional paths.

Two-line functional change.

## Scope / compatibility

- **Only affects `@Model` types that declare an explicit, reusable `id`.** For a default-`id` model `.id == modelID`, so every distinct instance still replaces exactly as before — no behavior change.
- To intentionally swap in different state under the same domain key: mutate the existing child, or give the new instance a distinct `id`.

No DEBUG "you replaced instead of mutating" notice was added: the framework cannot distinguish "replace to update state" from "pass a fresh same-id instance for continuity" (the latter is the legitimate, tested pattern in `ActivateTests.testChildrenCaseActivation`), so such a notice would false-positive on correct usage. The contract is documented in the CHANGELOG instead.

## Validation

Full suite green on **serial and parallel** (782 tests; only the documented known-issue flakes). CHANGELOG `[Unreleased]` updated; `ExplicitIdReplacementTests` updated to assert single-child continuity plus a different-`id` replacement control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)