### PR TITLE
Fix AB-BA memoize/TestAccess lock-order deadlock (sibling of #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes are documented here. The format follows [Keep a Changelog](h
 
 ## [Unreleased]
 
+### Fixed
+
+- **`memoize`'s first-access setup no longer deadlocks against a concurrent property write under `.modelTesting`.** A direct sibling of the 1.0.6 `reduceHierarchy` fix, on the path that fix did not cover. `memoize`'s first-access block took the context (hierarchy) lock — `context.lock { … }` — and only then, through the nested `Context.transaction`, the `TestAccess` write lock (`acquireWriteLock()`), i.e. **context → TestAccess**. That inverts the **TestAccess → context** order every writer uses (`Context._modify` / `Context.transaction` acquire `acquireWriteLock()` *before* `lock.lock()`), so a thread doing a first-access `memoize` (holding the context lock, awaiting the `TestAccess` lock) racing a writer (holding the `TestAccess` lock, awaiting the context lock) was a genuine AB-BA deadlock — observed as `settle()`/`expect()` hanging (never reaching a fixpoint) when one model activates and reads a memoized value while another writes a property, both on the concurrent drive. It was captured live with `sample` on a hung test host: a model activation whose `onActivate` read a memoized child value while drain-executor model tasks ran writes. `memoize` now acquires the `TestAccess` write lock **before** the context lock, matching the canonical order; both locks are recursive, so the nested `Context.transaction` re-enters harmlessly. Locking-discipline change only — no behavior change, and a no-op outside `.modelTesting` (`ModelAccess.acquireWriteLock()` is a no-op in production).
+
 ---
 
 ## [1.0.6] — Single-`@Model`-child same-`id` continuity; `reduceHierarchy` lock-order deadlock fix

--- a/Sources/SwiftModel/Model+Changes.swift
+++ b/Sources/SwiftModel/Model+Changes.swift
@@ -572,7 +572,26 @@ private extension ModelNode {
             return entry.value as! T
         }
 
-        // First access: set up tracking
+        // First access: set up tracking.
+        //
+        // Acquire the TestAccess write lock (A) BEFORE the context hierarchy
+        // lock (B), matching the canonical A→B order that
+        // `Context.transaction` establishes (`acquireWriteLock()` then `lock`).
+        // This block used to take B (`context.lock`) and only acquire A inside
+        // the nested `context.transaction` below — i.e. B→A. A concurrent
+        // `transaction` on another thread takes A→B, so the two opposite orders
+        // form an AB-BA deadlock. It bites only under `.modelTesting` (the base
+        // `ModelAccess.acquireWriteLock` is a no-op in production), where it
+        // wedged the serial macOS package test plan: a synchronous model
+        // activation running `memoize` here (holding B, awaiting A) against a
+        // drain-executor model task inside `transaction` (holding A, awaiting
+        // B) — captured live with `sample` on a hung xctest. Same lock-pair /
+        // AB-BA family as the `reduceHierarchy` fix (#29), on the site #29 did
+        // not cover. Both locks are recursive, so the nested transaction's own
+        // acquireWriteLock/`lock` re-enter harmlessly.
+        let memoizeWriteLockHolder = ModelAccess.active ?? ModelAccess.current
+        memoizeWriteLockHolder?.acquireWriteLock()
+        defer { memoizeWriteLockHolder?.releaseWriteLock() }
         return context.lock {
 
             // Double-check: another thread may have set up tracking between our nil check above
@@ -606,10 +625,9 @@ private extension ModelNode {
 
             // First access: set up tracking with didModify callback.
             // memoize setup doesn't issue user-property writes via stateTransaction,
-            // so we don't need an accessBox here — pass the same `active ?? current`
-            // chain `Context.transaction` uses as a fallback. See the long
-            // comment block at `Context.transaction(writeLockHolder:_:)`.
-            let memoizeWriteLockHolder = ModelAccess.active ?? ModelAccess.current
+            // so we don't need an accessBox here — `memoizeWriteLockHolder` (the
+            // same `active ?? current` chain `Context.transaction` uses) was
+            // acquired above, BEFORE the context lock, to preserve the A→B order.
             let (cancellable, forceNextUpdate) = context.transaction(writeLockHolder: memoizeWriteLockHolder) {
                 // Enable coalescing by default to batch multiple dependency changes during transactions
                 // Can be disabled via ModelOption.disableMemoizeCoalescing for testing

--- a/Tests/SwiftModelTests/InheritCancellationContextTests.swift
+++ b/Tests/SwiftModelTests/InheritCancellationContextTests.swift
@@ -104,6 +104,7 @@ struct InheritCancellationContextTests {
     /// cancelling the outer forEach also cancels in-flight per-element tasks.
     @Test func testForEachCancelPreviousInheritsContext() async throws {
         @Locked var processedCount = 0
+        @Locked var interruptedBeforeWork = false
         let channel = AsyncChannel<Int>()
         let workStarted = AsyncChannel<()>()
 
@@ -112,22 +113,37 @@ struct InheritCancellationContextTests {
 
             let subscription = model.forEach(channel, cancelPrevious: true) { value in
                 await workStarted.send(())
-                // Long-running work per element
-                try await Task.sleep(nanoseconds: 500_000_000)
+                // Per-element work long enough that the body can ONLY finish via
+                // cancellation, never via the wall clock. (The old 500 ms sleep
+                // raced the fixed post-cancel wait: under parallel CI load >500 ms
+                // could elapse between work-start and the assert, the sleep then
+                // completed and `+= value` ran → flaky `processedCount → 1`.)
+                do {
+                    try await Task.sleep(nanoseconds: 30_000_000_000)
+                } catch {
+                    // Cancellation interrupted the sleep before the write below.
+                    $interruptedBeforeWork.wrappedValue = true
+                    throw error
+                }
                 $processedCount.wrappedValue += value
             } catch: { _ in }
 
             var startIt = workStarted.makeAsyncIterator()
 
-            // Send first value and let it start processing
+            // Send first value and let it start processing.
             await channel.send(1)
             await startIt.next()
 
-            // Cancel the forEach before processing completes
+            // Cancel the forEach before processing completes.
             subscription.cancel()
 
-            // Processing should be interrupted (processedCount stays 0)
-            try await Task.sleep(nanoseconds: 100_000_000)
+            // Deterministic: wait until the in-flight body actually observes the
+            // cancellation (flag set in its catch), bounded generously so a
+            // saturated CI box still converges. Resolves in ms once cancellation
+            // propagates; if cancellation failed to interrupt the body this times
+            // out and fails — which is the real regression this test guards.
+            try await waitUntil($interruptedBeforeWork.value == true, timeout: 10_000_000_000)
+            // …and the cancelled body never reached its write.
             #expect(processedCount == 0)
         }
     }

--- a/Tests/SwiftModelTests/MemoizeLockOrderDeadlockTests.swift
+++ b/Tests/SwiftModelTests/MemoizeLockOrderDeadlockTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import SwiftModel
+
+// Regression test for an AB-BA deadlock between the context hierarchy lock
+// (`AnyContext.lock` — the recursive lock shared by every context in a
+// hierarchy; call it B) and the `TestAccess` write lock (A), on the `memoize`
+// FIRST-ACCESS path.
+//
+// The cycle, captured live with `sample` on a wedged xctest:
+//
+//   • memoize thread — `memoize`'s first-access setup took the context lock B
+//     (`context.lock { … }`) and only THEN, through the nested
+//     `Context.transaction`, the TestAccess write lock A — i.e. B→A.
+//
+//   • writer thread — any `Context._modify` of a @Model property goes through
+//     `Context.transaction`, which acquires A FIRST (`acquireWriteLock()`) and
+//     then B (`lock`) — i.e. A→B (the canonical order the WriteLockOrdering /
+//     #29 fixes established).
+//
+//   Two threads, opposite orders → the memoize thread holds B and waits for A;
+//   the writer holds A and waits for B → permanent hang.
+//
+// Reachable ONLY under `.modelTesting`: the base `ModelAccess.acquireWriteLock()`
+// is a no-op in production, so A does not exist there — this never wedges a
+// shipping app, only the test plan. Same lock-pair / AB-BA family as
+// `HierarchyLockOrderDeadlockTests` (#29); that fix hoisted `willAccessParents()`
+// out of the context lock in `reduceHierarchy`, but the equivalent inversion on
+// the `memoize` first-access path remained. The fix acquires A before B in
+// `memoize`'s first-access block, restoring the A→B order.
+//
+// Authoritative reproduction: the downstream parallel-apple macOS package test
+// plan (122 suites, serial) hung ~every run before this fix — a `SDKRootModel`
+// activation whose `onActivate` read a memoized child value while drain-executor
+// model tasks ran `Context._modify` writes — and passes after.
+//
+// NOTE ON REPRODUCIBILITY: like #29, the timing window is narrow; a small
+// synthetic graph does not reliably hit it without test-only seams into
+// TestAccess's locks. This is therefore a CONCURRENCY SMOKE TEST — it drives the
+// exact path (memoize first-access during activation, concurrent with sibling
+// `Context._modify` writes) across many fresh graphs and asserts each settles and
+// stays correct. The deterministic guard is the downstream plan above.
+
+@Model private struct MemoLeaf {
+    var n = 0
+    var written = 0
+
+    func onActivate() {
+        // First-access `memoize` on this fresh context — the B→A path under test.
+        // (Each new leaf instance has its own `_memoizeCache`, so every activation
+        // is a first access.) The returned value is irrelevant; we only need the
+        // first-access lock dance to run concurrently with the writers below.
+        _ = node.memoize(for: "doubled") { self.n &* 2 }
+
+        // Concurrently fire a writer on the drain executor (`Context._modify` →
+        // A→B) during the same activation wave, so some leaves are mid-memoize
+        // (B held, awaiting A) while others run writes (A held, awaiting B).
+        node.onChange(of: n, initial: true) { _, _ in
+            for _ in 0 ..< 12 { self.written &+= 1 }
+        }
+    }
+}
+
+@Model private struct MemoBranch {
+    var leaves: [MemoLeaf] = []
+}
+
+@Model private struct MemoRoot {
+    var branches: [MemoBranch] = []
+}
+
+@Suite(.modelTesting(exhaustivity: .off))
+struct MemoizeLockOrderDeadlockTests {
+
+    /// Smoke test: many leaves activate concurrently, each reading a first-access
+    /// memoized value (context→TestAccess order pre-fix) while writers fire
+    /// `Context._modify` (TestAccess→context). Pre-fix this wedged on the AB-BA
+    /// inversion and never reached a `settle()` fixpoint; with the fix every
+    /// iteration settles and stays correct.
+    @Test func memoizeFirstAccessConcurrentWithWritesStaysSettled() async {
+        for _ in 0 ..< 40 {
+            let root = MemoRoot(branches: (0 ..< 4).map { _ in
+                MemoBranch(leaves: (0 ..< 5).map { i in MemoLeaf(n: i) })
+            }).withAnchor()
+            await settle()
+            // Reaching here at all is the assertion that matters: pre-fix the
+            // AB-BA deadlock meant `settle()` never returned (hung to the cap).
+            #expect(root.branches.count == 4)
+            #expect(root.branches.allSatisfy { $0.leaves.count == 5 })
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes an **AB-BA deadlock** between the context (hierarchy) lock and the `TestAccess` write lock on the **`memoize` first-access path** — the direct sibling of the 1.0.6 `reduceHierarchy` fix (#29), on the path #29 did not cover.

`memoize`'s first-access setup takes the context lock **B** (`context.lock { … }`) and only then, through the nested `Context.transaction`, the `TestAccess` write lock **A** (`acquireWriteLock()`) — i.e. **B→A**. Every writer (`Context._modify` / `Context.transaction`) takes **A→B** (`acquireWriteLock()` before `lock.lock()`). Run concurrently, the two opposite orders deadlock:

- **memoize thread** — holds B (context lock), awaits A (TestAccess lock)
- **writer thread** — holds A (TestAccess lock), awaits B (context lock)

Reachable **only under `.modelTesting`**: the base `ModelAccess.acquireWriteLock()` is a no-op in production, so lock A doesn't exist there. It never wedges a shipping app — only the test plan.

## How it was found

Captured live with `sample` on a hung `xctest` in a downstream consumer's macOS package test plan (122 suites, serial). The hang victim **varied run-to-run** — whichever model was mid-activation when the race landed — which is exactly why load-aimed mitigations (serial execution, build governors, timeout scaling) never cured it: a deadlock is immune to all of them. Three independent stack samples all showed:

- main thread: `onActivate()` → memoized child read → `memoize` first-access → `context.lock` (B held) → `Context.transaction` → `TestAccess.acquireWriteLock()` → **blocked on A**
- drain-executor model tasks: `Context.transaction` (A held) → `lock` → **blocked on B**

All threads `__psynch_mutexwait`, 100% of samples — a hard deadlock, not starvation.

## Fix

Acquire the `TestAccess` write lock **before** the context lock in `memoize`'s first-access block, matching the canonical A→B order that `Context.transaction` establishes. Both locks are recursive, so the nested `Context.transaction`'s own `acquireWriteLock`/`lock` re-enter harmlessly. Locking-discipline change only — no behavior change, no-op outside `.modelTesting`.

## Tests

- **New:** `MemoizeLockOrderDeadlockTests` — a concurrency smoke test (mirroring `HierarchyLockOrderDeadlockTests`): many leaves activate, each running a first-access `memoize` concurrently with sibling `Context._modify` writes; asserts each iteration settles. The narrow timing window means the deterministic guard is the downstream plan below.
- **No regression:** `MemoizeThrashTests`, `MemoizeDirtyObservationTests`, `HierarchyLockOrderDeadlockTests` (#29) all pass.
- **Authoritative reproduction:** the downstream macOS package plan (503 tests / 122 suites) hung ~every run before this fix (ran 3.5h until killed) and **passes in ~5 min after** — zero stalls.

---

## Also in this PR — stabilize a pre-existing Linux-parallel flake

Adding the new suite increased Linux (parallel) load and reliably surfaced a pre-existing flake in the unrelated `testForEachCancelPreviousInheritsContext` (a test with a history of "Test stability fixes"). It asserted a cancelled `forEach` body's `+= value` never runs, but did so by racing a fixed 100 ms wall-clock wait against a 500 ms work sleep — under load, >500 ms elapsed and the work completed first (`processedCount → 1`). Made deterministic following the repo's `waitUntil` convention: the work can now only finish via cancellation, the body records (in a `@Locked` flag) that it was interrupted before the write, and the test `waitUntil`s that flag. Passes 5/5 locally (~0.017 s each).

**Stability verified:** CI green across **3 consecutive runs** on this branch (`run_attempt=3`, all jobs incl. Linux parallel/serial, macOS parallel/serial, WASM, Android).
