### PR TITLE
Scale ReactiveWaitInfrastructureTests cancel→resume bounds by SWIFT_MODEL_TIMEOUT_SCALE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes are documented here. The format follows [Keep a Changelog](h
 
 - **`Context.onActivate()` no longer data-races on `pendingActivation` under concurrent activation.** When two unsynchronized writers mutate the same identified-collection property concurrently (the field "two RMW writers" pattern), each `_performCollectionSet` runs its `structuralChange` re-activation loop (`element.activate()` → `onActivate()`) **outside** the `stateTransaction` lock. Two such loops calling `onActivate()` on the same child context then raced on the unsynchronized `pendingActivation` `var` — one writing `nil` while another read/called it — surfaced directly by ThreadSanitizer (`swift test --sanitize=thread`). The activation closure is now read-and-niled **under the hierarchy lock** and consumed only by the single caller that wins the atomic anchored→active transition in `super.onActivate()` (losers never touch it). Locking-discipline change only — single-threaded behaviour is unchanged (the value was always consumed exactly once by the first activation). Regression coverage in `ContainerReanchorResetTests` (run under TSan to exercise the race).
 
----
+### Tests
+
+- **`ReactiveWaitInfrastructureTests`'s cancel→resume bounds now scale with `SWIFT_MODEL_TIMEOUT_SCALE`.** The three "a cancelled wait resumes within N seconds" hang-detector assertions used raw nanosecond literals (`2_000_000_000` / `5_000_000_000`) that — unlike every other test-infra wall-clock budget — did **not** multiply by `ModelTestingTraitOptions.timeoutScale`. Under Linux-parallel CI saturation the cancel→resume measured 2.0–3.3 s, tipping the raw 2 s bounds over and failing `backgroundCallQueue_waitUntilIdle_cancellable` / `backgroundCallQueue_waitForCurrentItems_cancellable` — a load flake, not a real hang. The bounds now scale (CI runs `×3`), so a saturated runner has headroom while a genuine cancellation hang still exceeds the scaled budget. Test-only.
 
 ## [1.0.7] — `memoize` first-access lock-order deadlock fix
 

--- a/Tests/SwiftModelTests/ReactiveWaitInfrastructureTests.swift
+++ b/Tests/SwiftModelTests/ReactiveWaitInfrastructureTests.swift
@@ -75,9 +75,11 @@ struct ReactiveWaitInfrastructureTests {
         // Under x1000 parallel-test stress the cooperative pool's scheduling
         // of Task.sleep wake + task.cancel + onCancel + continuation.resume
         // can stretch to 1.5-2 s. A real "cancellation hung" bug would still
-        // exceed 5 s.
-        #expect(elapsedNs < 5_000_000_000,
-                "cancel→resume should land within 5 s; took \(elapsedNs) ns")
+        // exceed the (scaled) bound. Scaled by `timeoutScale` (env
+        // `SWIFT_MODEL_TIMEOUT_SCALE`, CI=3) like every other test-infra
+        // wall-clock budget, so a saturated CI runner doesn't read as a hang.
+        #expect(elapsedNs < UInt64(5_000_000_000 * ModelTestingTraitOptions.timeoutScale),
+                "cancel→resume should land within 5 s (×\(ModelTestingTraitOptions.timeoutScale)); took \(elapsedNs) ns")
     }
 
     // MARK: - 2. CallQueue wait primitives are cancellation-aware
@@ -106,8 +108,12 @@ struct ReactiveWaitInfrastructureTests {
         await waiter.value
         let elapsedNs = Self.elapsedNs(since: startNs)
 
-        #expect(elapsedNs < 2_000_000_000,
-                "waitUntilIdle should resume within 2 s of cancel; took \(elapsedNs) ns")
+        // Scaled by `timeoutScale` (env `SWIFT_MODEL_TIMEOUT_SCALE`, CI=3) like the
+        // other cancel→resume hang-detector bounds — a saturated Linux-parallel
+        // runner was measured taking 2.0–3.3 s for this cancel→resume, which the
+        // raw 2 s literal misread as a hang. A real hang still exceeds the scaled bound.
+        #expect(elapsedNs < UInt64(2_000_000_000 * ModelTestingTraitOptions.timeoutScale),
+                "waitUntilIdle should resume within 2 s of cancel (×\(ModelTestingTraitOptions.timeoutScale)); took \(elapsedNs) ns")
     }
 
     /// `onIdle` fires immediately when the queue is already idle.
@@ -192,8 +198,12 @@ struct ReactiveWaitInfrastructureTests {
         await waiter.value
         let elapsedNs = Self.elapsedNs(since: startNs)
 
-        #expect(elapsedNs < 2_000_000_000,
-                "waitForCurrentItems should resume within 2 s of cancel; took \(elapsedNs) ns")
+        // Scaled by `timeoutScale` (env `SWIFT_MODEL_TIMEOUT_SCALE`, CI=3) like the
+        // other cancel→resume hang-detector bounds — a saturated Linux-parallel
+        // runner was measured taking 2.0–3.3 s for this cancel→resume, which the
+        // raw 2 s literal misread as a hang. A real hang still exceeds the scaled bound.
+        #expect(elapsedNs < UInt64(2_000_000_000 * ModelTestingTraitOptions.timeoutScale),
+                "waitForCurrentItems should resume within 2 s of cancel (×\(ModelTestingTraitOptions.timeoutScale)); took \(elapsedNs) ns")
     }
 
     // MARK: - 3. _withTestTimeout


### PR DESCRIPTION
## Summary

Fixes the post-#31-merge `main` CI red on **Linux (parallel)** — which is a **pre-existing load flake, not a #31 regression**.

`ReactiveWaitInfrastructureTests`' three "a cancelled wait resumes within N seconds" hang-detector assertions used raw nanosecond literals (`2_000_000_000` / `5_000_000_000`) that — unlike every other test-infra wall-clock budget (`TestExpect`, `TestWaitSupport`, `TestExecutorDrive`, all `× ModelTestingTraitOptions.timeoutScale`) — did **not** scale with `SWIFT_MODEL_TIMEOUT_SCALE`.

Under Linux-parallel CI saturation the cancel→resume was measured at **2.0–3.3 s**, tipping the raw 2 s bounds over and failing:

- `backgroundCallQueue_waitUntilIdle_cancellable` (`elapsedNs` 2.08 s, then 3.31 s on re-run)
- `backgroundCallQueue_waitForCurrentItems_cancellable`

That's a load symptom, not a real hang or a regression (the merged #31 change — `Context.onActivate` locking — and its `ContainerReanchorResetTests` both pass).

## Fix

Scale the three bounds by `ModelTestingTraitOptions.timeoutScale` (CI runs `×3`), mirroring the file's own line-502 convention. A saturated runner now has headroom; a genuine cancellation hang still exceeds the scaled budget. **Test-only.**

## Verification

`scripts/test --filter SwiftModelTests.ReactiveWaitInfrastructureTests` — all 21 pass, including the two previously-flaking tests. No new compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)