### PR TITLE
Harden two parallel-load-sensitive .modelTesting tests (no library change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes are documented here. The format follows [Keep a Changelog](h
 
 ## [Unreleased]
 
+### Changed
+
+- **Test-suite hardening only — no library change.** Two `.modelTesting` tests that flaked exclusively under `macOS (parallel)` CI saturation (and full-suite parallel `swift test` under load), while passing serially, on Linux, and in isolation, are now load-independent:
+  - `ChildActivationTaskTests.childTasksCompleteBeforeTeardown` — the child `node.task`'s async work moved from an off-executor `ImmediateClock.sleep` to an on-executor `Task.yield` chain (the validated `DrainItem`/`settleIsLoadIndependentAcrossChildTasks` shape). The off-executor sleep was invisible to the executor-drive's inactivity watchdog, so under saturation the test's wall-clock drifted past the `.modelTesting` trait cap (~103 s on a constrained CI runner vs. the 90 s scaled cap). On-executor suspensions keep progress visible to the watchdog, so a slow-but-progressing run never trips the cap. The unkeyed-task-vs-`checkExhaustion` teardown race under test is unchanged (`expect`, not `settle`, preserves the tight teardown window).
+  - `ClockTests` is now `.serialized` so its unbounded `ImmediateClock` timer producer (`testImmediateClock`) no longer runs concurrently with the registration-sensitive `testClockStepByStep` and starves it. No semantic change to either test.
+
 ---
 
 ## [1.0.8] — Cross-construction init-accessor state bleed fix; `pendingActivation` activation race fix

--- a/Tests/SwiftModelTests/ChildActivationTaskTests.swift
+++ b/Tests/SwiftModelTests/ChildActivationTaskTests.swift
@@ -1,6 +1,5 @@
 import Testing
 import SwiftModel
-import Clocks
 
 // MARK: - Models
 
@@ -17,15 +16,38 @@ import Clocks
 /// so AnyCancellable.contexts is empty and the task is NOT keyed with .onActivate.
 /// cancelAllRecursively(for: .onActivate) therefore does NOT cancel it; the task must
 /// complete naturally before checkExhaustion reads Cancellations.registered.
+///
+/// The async work is a short on-executor `Task.yield` chain rather than a
+/// `clock.sleep`. Both give the task "several suspension points then a write",
+/// but they differ in *where* the suspensions park:
+///
+///   • A `clock.sleep` (even `ImmediateClock`) parks the continuation *off* the
+///     per-test drain executor — invisible to the executor-drive's activity
+///     accounting. While every child is parked off-executor at once, the drive
+///     sees a no-activity window, and under `macOS (parallel)` saturation that
+///     window stretched the test's wall-clock past the `.modelTesting` trait cap
+///     (observed ~103 s on a constrained CI runner, > the 90 s scaled cap).
+///   • `Task.yield` re-enqueues on the drain executor, so every suspension is
+///     *on* the executor. The trait cap is an inactivity watchdog keyed on this
+///     test's executor activity (executor-drive default, macOS 15+); continuous
+///     on-executor progress keeps resetting it, so a slow-but-progressing run
+///     under load never trips it — the load-independence the drive is built to
+///     provide. This mirrors the validated `DrainItem` shape in
+///     `ExecutorDrainSettleTests.settleIsLoadIndependentAcrossChildTasks` (run
+///     60× under CPU load). See `Docs/test-determinism-executor-drain.md`.
+///
+/// The teardown race under test is unchanged: the task is still unkeyed and must
+/// unregister() naturally around checkExhaustion — `Task.yield` vs `clock.sleep`
+/// does not affect that.
 @Model private struct ChildTaskItem: Sendable, Identifiable {
     let id: Int
     var loaded: Bool = false
 
     func onActivate() {
         node.task {
-            try await node.continuousClock.sleep(for: .milliseconds(200))
+            for _ in 0..<6 { await Task.yield() }
             loaded = true
-        } catch: { _ in }
+        }
     }
 }
 
@@ -34,8 +56,8 @@ import Clocks
 /// Regression suite for the "Active task still running at teardown" race.
 ///
 /// Root cause: `node.task { }` called from onActivate() during a GCD drain is not keyed
-/// with .onActivate. It completes quickly (ImmediateClock) but its unregister() call on
-/// the cooperative pool races with checkExhaustion reading Cancellations.registered.
+/// with .onActivate. It completes quickly but its unregister() call races with
+/// checkExhaustion reading Cancellations.registered.
 ///
 /// Fix: checkExhaustion yields to the scheduler after cancelAllRecursively so naturally-
 /// completing tasks can call unregister() before the exhaustion check runs.
@@ -46,12 +68,13 @@ struct ChildActivationTaskTests {
     /// Without the fix this fails ~2/100 runs with:
     ///   "Active task 'onActivate() @ ...' of `ChildTaskItem` still running"
     @Test func childTasksCompleteBeforeTeardown() async {
-        let parent = ChildTaskParent().withAnchor {
-            $0.continuousClock = ImmediateClock()
-        }
+        let parent = ChildTaskParent().withAnchor()
         parent.items = (0..<5).map { ChildTaskItem(id: $0) }
-        // Wait for all onActivate tasks to complete (loaded becomes true for each item).
-        // checkExhaustion then verifies no tasks are still registered as running.
+        // Wait for all onActivate tasks to complete (loaded becomes true for each
+        // item), then teardown runs checkExhaustion immediately after — the tight
+        // window that exercises the unregister()-vs-checkExhaustion race. `expect`
+        // (not `settle`) is deliberate: `settle` would wait for full drain
+        // quiescence first, closing that window and neutering the regression.
         await expect(parent.items.count == 5 && parent.items.allSatisfy { $0.loaded })
     }
 }

--- a/Tests/SwiftModelTests/ClockTests.swift
+++ b/Tests/SwiftModelTests/ClockTests.swift
@@ -16,7 +16,22 @@ private struct TimerModel {
     }
 }
 
-@Suite(.modelTesting)
+// `.serialized` so the suite's three clock tests never run concurrently *with
+// each other*. `testImmediateClock` drives an ImmediateClock `timer(...)`, which
+// is an unbounded producer — it fires intervals as fast as the model can process
+// them for the whole lifetime of the test. Running that infinite producer
+// alongside the registration-sensitive `testClockStepByStep` (which needs its
+// `clock.sleep` subscription to land between `advance`es) starved both under
+// parallel load: the producer monopolised in-process cooperative slots while the
+// step-by-step test's precise scheduling was waiting for them. Serializing the
+// suite removes that intra-suite self-amplification. (The sibling load
+// sensitivity in `childTasksCompleteBeforeTeardown` is addressed there by moving
+// the child task's async work *onto* the drain executor so the trait cap's
+// inactivity watchdog sees continuous progress; `testImmediateClock`'s unbounded
+// producer can't lean on that — its `expect` resolves on the first tick and then
+// an infinite stream of ticks keeps the executor busy regardless — so reducing
+// its in-suite concurrency is the available test-side lever.)
+@Suite(.modelTesting, .serialized)
 struct ClockTests {
     /// TestClock lets you advance time explicitly and assert intermediate states.
     @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)


### PR DESCRIPTION
## Summary

Two `.modelTesting` tests flaked **only** under the `macOS (parallel)` CI job (and full-suite parallel `swift test` under load), while passing on macOS-serial, Linux parallel/serial, WASM, Android, and in isolation:

1. `ClockTests.testImmediateClock()`
2. `ChildActivationTaskTests.childTasksCompleteBeforeTeardown()`

Both surfaced as `[TRAIT timeout] … exceeded …s wall-clock cap`. Root cause is **cooperative-pool starvation** under heavy parallel scheduling pushing each test's wall-clock-bounded wait past the `.modelTesting` trait cap — test-suite fragility, **not** a product bug (they pass serially and in isolation; `main`'s macOS-parallel had been green for 8 runs before randomly tipping). This PR is **test-suite hardening only — no `Sources/` change.**

## What changed

### `childTasksCompleteBeforeTeardown` — make the wait watchdog-visible
The child `node.task`'s async work was an `ImmediateClock.sleep(...)`, whose continuation parks **off** the per-test drain executor. The trait cap is an *inactivity watchdog* keyed on this test's executor activity (executor-drive default, macOS 15+); an off-executor park is invisible to it, so under saturation the test's wall-clock drifted past the cap (~103 s observed on a constrained CI runner vs. the 90 s `SWIFT_MODEL_TIMEOUT_SCALE=3` cap).

Moved the work to an on-executor `Task.yield` chain — the exact shape the framework already validates as load-independent in `ExecutorDrainSettleTests.settleIsLoadIndependentAcrossChildTasks` / `DrainItem` (run 60× under CPU load). Every suspension is now on the executor, so continuous progress keeps resetting the watchdog and a slow-but-progressing run never trips the cap.

Kept `expect` (not `settle`): the immediate teardown right after it is the tight window that exercises the **unkeyed-task-vs-`checkExhaustion`** race this test regresses. `settle` would wait for full drain quiescence first and *neuter* the regression. The race itself is unchanged (`Task.yield` vs `clock.sleep` doesn't affect that the task is unkeyed and unregisters around teardown).

> ⚠️ I rejected an earlier `settle()`-based version: it both broke correctness (the off-executor sleep means `settle` returns at a fixpoint while `loaded` is still false → assertion fails under load) and would have neutered the teardown race. Caught it under saturation before it shipped.

### `ClockTests` → `.serialized`
`testImmediateClock` drives an **unbounded** `ImmediateClock` `timer(...)` producer (fires as fast as the model processes it for the whole test). Running it concurrently with the registration-sensitive `testClockStepByStep` starved both. `.serialized` removes that intra-suite self-amplification. `testImmediateClock`'s `expect` resolves on the first tick and an infinite tick stream then keeps the executor busy, so it can't lean on `settle()` — reducing in-suite concurrency is the available lever. No semantic change to either test.

## Verification (reproduce → fix → verify)
- **Reproduced** the mechanism locally by saturating the 10-core machine with CPU hogs: under contention `childTasks` climbed from ~5 s to 13–16 s (toward the cap), confirming the wall-clock-vs-starvation interaction.
- **After the fix**, under sustained CPU saturation: `childTasks` drops to ~2.5 s and both suites pass **12/12** in a loop; the **full parallel suite** stays green under load.
- **Clean runs**, both CI modes: parallel ✅ and `--no-parallel` ✅ — exactly **28 known issues**, zero new failures/regressions.
- Warning-free build.

CI (`macOS (parallel)` + serial, Linux, WASM, Android) is the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)